### PR TITLE
Implement auto_consolidation_sweep functionality

### DIFF
--- a/episemic/api.py
+++ b/episemic/api.py
@@ -301,7 +301,7 @@ class EpistemicAPI:
                             embedding, top_k, {"tags": tags[0]} if tags else None
                         )
                         # Convert to SearchResult format
-                        from .models import SearchResult, Memory
+                        from .models import Memory, SearchResult
                         results = []
                         for result in search_results:
                             memory = Memory(

--- a/episemic/simple.py
+++ b/episemic/simple.py
@@ -1,7 +1,6 @@
 """Simple, user-friendly API for Episemic Core."""
 
 import asyncio
-from typing import Any
 
 from .api import EpistemicAPI
 from .config import EpistemicConfig

--- a/tests/test_api_integration.py
+++ b/tests/test_api_integration.py
@@ -12,7 +12,7 @@ from episemic.models import Memory, SearchQuery
 
 
 @pytest.mark.asyncio
-@patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer')
+@patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer")
 async def test_api_duckdb_backend_selection(mock_transformer):
     """Test API automatically selecting DuckDB backend."""
     # Mock the sentence transformer
@@ -42,13 +42,11 @@ async def test_api_duckdb_backend_selection(mock_transformer):
         success = await api.initialize()
         assert success is True
         assert api.hippocampus is not None
-        assert hasattr(api.hippocampus, 'get_embedding')  # DuckDB hippocampus
+        assert hasattr(api.hippocampus, "get_embedding")  # DuckDB hippocampus
 
         # Test storing memory
         memory_id = await api.store_memory(
-            text="Test memory for API integration",
-            title="API Test",
-            tags=["api", "test"]
+            text="Test memory for API integration", title="API Test", tags=["api", "test"]
         )
         assert memory_id is not None
 
@@ -63,7 +61,7 @@ async def test_api_duckdb_backend_selection(mock_transformer):
 
 
 @pytest.mark.asyncio
-@patch('qdrant_client.QdrantClient')
+@patch("qdrant_client.QdrantClient")
 async def test_api_qdrant_preference_with_availability(mock_qdrant_client):
     """Test API preferring Qdrant when available."""
     # Mock successful Qdrant connection
@@ -83,8 +81,8 @@ async def test_api_qdrant_preference_with_availability(mock_qdrant_client):
 
 
 @pytest.mark.asyncio
-@patch('qdrant_client.QdrantClient')
-@patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer')
+@patch("qdrant_client.QdrantClient")
+@patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer")
 async def test_api_qdrant_fallback_to_duckdb(mock_transformer, mock_qdrant_client):
     """Test API falling back to DuckDB when Qdrant is unavailable."""
     # Mock the sentence transformer
@@ -108,7 +106,7 @@ async def test_api_qdrant_fallback_to_duckdb(mock_transformer, mock_qdrant_clien
 
 
 @pytest.mark.asyncio
-@patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer')
+@patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer")
 async def test_api_fallback_search_functionality(mock_transformer):
     """Test API fallback search when retrieval engine is disabled."""
     # Mock the sentence transformer
@@ -129,9 +127,7 @@ async def test_api_fallback_search_functionality(mock_transformer):
 
     # Store a memory
     memory_id = await api.store_memory(
-        text="Fallback search test memory",
-        title="Fallback Test",
-        tags=["fallback", "search"]
+        text="Fallback search test memory", title="Fallback Test", tags=["fallback", "search"]
     )
     assert memory_id is not None
 
@@ -150,9 +146,9 @@ async def test_api_initialization_failure_handling():
     api = EpistemicAPI(config)
 
     # Mock hippocampus to fail initialization
-    with patch.object(api, 'hippocampus', None):
-        with patch.object(api, '_should_use_duckdb', return_value=True):
-            with patch('episemic.api.DuckDBHippocampus') as mock_duckdb:
+    with patch.object(api, "hippocampus", None):
+        with patch.object(api, "_should_use_duckdb", return_value=True):
+            with patch("episemic.api.DuckDBHippocampus") as mock_duckdb:
                 mock_duckdb.side_effect = Exception("Initialization failed")
 
                 success = await api.initialize()
@@ -161,7 +157,7 @@ async def test_api_initialization_failure_handling():
 
 
 @pytest.mark.asyncio
-@patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer')
+@patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer")
 async def test_api_memory_operations_comprehensive(mock_transformer):
     """Test comprehensive memory operations through API."""
     # Mock the sentence transformer
@@ -186,7 +182,7 @@ async def test_api_memory_operations_comprehensive(mock_transformer):
         tags=["comprehensive", "test"],
         metadata={"test_type": "comprehensive", "priority": "high"},
         store_in_hippocampus=True,
-        store_in_cortex=False
+        store_in_cortex=False,
     )
     assert memory_id is not None
 
@@ -195,11 +191,7 @@ async def test_api_memory_operations_comprehensive(mock_transformer):
     # May be None if retrieval engine is disabled
 
     # Test search with tags
-    results = await api.search(
-        query="comprehensive test",
-        top_k=5,
-        tags=["comprehensive"]
-    )
+    results = await api.search(query="comprehensive test", top_k=5, tags=["comprehensive"])
     assert isinstance(results, list)
 
     # Test health check
@@ -209,7 +201,7 @@ async def test_api_memory_operations_comprehensive(mock_transformer):
 
 
 @pytest.mark.asyncio
-@patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer')
+@patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer")
 async def test_api_context_manager(mock_transformer):
     """Test API context manager functionality."""
     # Mock the sentence transformer
@@ -227,10 +219,7 @@ async def test_api_context_manager(mock_transformer):
         assert api._initialized is True
 
         # Test basic operation
-        memory_id = await api.store_memory(
-            text="Context manager test",
-            title="Context Test"
-        )
+        memory_id = await api.store_memory(text="Context manager test", title="Context Test")
         assert memory_id is not None
 
 
@@ -272,7 +261,7 @@ def test_api_configuration_defaults():
 
 
 @pytest.mark.asyncio
-@patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer')
+@patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer")
 async def test_api_search_with_fallback_error_handling(mock_transformer):
     """Test API search fallback with error handling."""
     # Mock the sentence transformer
@@ -292,11 +281,11 @@ async def test_api_search_with_fallback_error_handling(mock_transformer):
     await api.initialize()
 
     # Mock hippocampus to not have get_embedding method
-    with patch.object(api.hippocampus, 'get_embedding', side_effect=AttributeError("No method")):
+    with patch.object(api.hippocampus, "get_embedding", side_effect=AttributeError("No method")):
         results = await api.search("test query")
         assert results == []
 
     # Mock hippocampus vector search to fail
-    with patch.object(api.hippocampus, 'vector_search', side_effect=Exception("Search failed")):
+    with patch.object(api.hippocampus, "vector_search", side_effect=Exception("Search failed")):
         results = await api.search("test query")
         assert results == []

--- a/tests/test_cli_basic.py
+++ b/tests/test_cli_basic.py
@@ -10,7 +10,7 @@ from typer.testing import CliRunner
 from episemic.cli.main import app
 
 
-@patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer')
+@patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer")
 def test_cli_version_command(mock_transformer):
     """Test CLI version command."""
     runner = CliRunner()
@@ -19,7 +19,7 @@ def test_cli_version_command(mock_transformer):
     assert "Episemic Core" in result.stdout
 
 
-@patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer')
+@patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer")
 def test_cli_health_command(mock_transformer):
     """Test CLI health command."""
     # Mock the sentence transformer
@@ -45,7 +45,7 @@ def test_cli_help():
     assert "get" in result.stdout
 
 
-@patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer')
+@patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer")
 def test_cli_store_command(mock_transformer):
     """Test CLI store command."""
     # Mock the sentence transformer
@@ -56,21 +56,28 @@ def test_cli_store_command(mock_transformer):
     runner = CliRunner()
 
     # Test basic store command
-    result = runner.invoke(app, [
-        "store",
-        "Test memory content",
-        "--title", "Test Title",
-        "--source", "cli_test",
-        "--tags", "test",
-        "--tags", "cli"
-    ])
+    result = runner.invoke(
+        app,
+        [
+            "store",
+            "Test memory content",
+            "--title",
+            "Test Title",
+            "--source",
+            "cli_test",
+            "--tags",
+            "test",
+            "--tags",
+            "cli",
+        ],
+    )
 
     # CLI will fail without external services available (expected behavior)
     assert result.exit_code == 1  # Application exits with 1 on error
-    assert ("Error storing memory" in result.output or "Connection refused" in result.output)
+    assert "Error storing memory" in result.output or "Connection refused" in result.output
 
 
-@patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer')
+@patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer")
 def test_cli_search_command(mock_transformer):
     """Test CLI search command."""
     # Mock the sentence transformer
@@ -81,18 +88,14 @@ def test_cli_search_command(mock_transformer):
     runner = CliRunner()
 
     # Test search command (will fail without services, which is expected)
-    search_result = runner.invoke(app, [
-        "search",
-        "search test",
-        "--top-k", "5"
-    ])
+    search_result = runner.invoke(app, ["search", "search test", "--top-k", "5"])
 
     # Search will fail without external services available (expected behavior)
     assert search_result.exit_code == 1
-    assert ("Error searching" in search_result.output or "Connection refused" in search_result.output)
+    assert "Error searching" in search_result.output or "Connection refused" in search_result.output
 
 
-@patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer')
+@patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer")
 def test_cli_init_command(mock_transformer):
     """Test CLI init command."""
     # Mock the sentence transformer
@@ -105,10 +108,10 @@ def test_cli_init_command(mock_transformer):
 
     # Init will fail without external services available (expected behavior)
     assert result.exit_code == 1
-    assert ("Failed to initialize" in result.output or "Connection refused" in result.output)
+    assert "Failed to initialize" in result.output or "Connection refused" in result.output
 
 
-@patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer')
+@patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer")
 def test_cli_consolidate_command(mock_transformer):
     """Test CLI consolidate command."""
     # Mock the sentence transformer

--- a/tests/test_cli_comprehensive.py
+++ b/tests/test_cli_comprehensive.py
@@ -18,7 +18,7 @@ def cli_runner():
 @pytest.fixture
 def mock_memory_system():
     """Mock the entire memory system."""
-    with patch('episemic.cli.main.get_memory_system') as mock_get:
+    with patch("episemic.cli.main.get_memory_system") as mock_get:
         mock_hippocampus = MagicMock()
         mock_cortex = MagicMock()
         mock_consolidation = MagicMock()
@@ -27,11 +27,11 @@ def mock_memory_system():
         mock_get.return_value = (mock_hippocampus, mock_cortex, mock_consolidation, mock_retrieval)
 
         yield {
-            'hippocampus': mock_hippocampus,
-            'cortex': mock_cortex,
-            'consolidation': mock_consolidation,
-            'retrieval': mock_retrieval,
-            'get_system': mock_get
+            "hippocampus": mock_hippocampus,
+            "cortex": mock_cortex,
+            "consolidation": mock_consolidation,
+            "retrieval": mock_retrieval,
+            "get_system": mock_get,
         }
 
 
@@ -46,7 +46,7 @@ def sample_memory():
         source="cli",
         tags=["test", "cli"],
         created_at=datetime.utcnow(),
-        access_count=5
+        access_count=5,
     )
 
 
@@ -55,7 +55,7 @@ def test_version_command(cli_runner):
     result = cli_runner.invoke(app, ["version"])
 
     assert result.exit_code == 0
-    assert "Episemic Core v1.0.2" in result.stdout
+    assert "Episemic Core v1.0.3" in result.stdout
 
 
 def test_help_command(cli_runner):
@@ -73,11 +73,12 @@ def test_help_command(cli_runner):
 
 def test_init_command_success(cli_runner):
     """Test successful init command."""
-    with patch('episemic.cli.main.Hippocampus') as mock_hippo, \
-         patch('episemic.cli.main.Cortex') as mock_cortex, \
-         patch('episemic.cli.main.ConsolidationEngine') as mock_consol, \
-         patch('episemic.cli.main.RetrievalEngine') as mock_retrieval:
-
+    with (
+        patch("episemic.cli.main.Hippocampus") as mock_hippo,
+        patch("episemic.cli.main.Cortex") as mock_cortex,
+        patch("episemic.cli.main.ConsolidationEngine") as mock_consol,
+        patch("episemic.cli.main.RetrievalEngine") as mock_retrieval,
+    ):
         result = cli_runner.invoke(app, ["init"])
 
         assert result.exit_code == 0
@@ -91,19 +92,28 @@ def test_init_command_success(cli_runner):
 
 def test_init_command_with_custom_params(cli_runner):
     """Test init command with custom parameters."""
-    with patch('episemic.cli.main.Hippocampus') as mock_hippo, \
-         patch('episemic.cli.main.Cortex') as mock_cortex, \
-         patch('episemic.cli.main.ConsolidationEngine'), \
-         patch('episemic.cli.main.RetrievalEngine'):
-
-        result = cli_runner.invoke(app, [
-            "init",
-            "--qdrant-host", "custom-qdrant",
-            "--qdrant-port", "9999",
-            "--postgres-host", "custom-postgres",
-            "--postgres-port", "5433",
-            "--postgres-db", "custom-db"
-        ])
+    with (
+        patch("episemic.cli.main.Hippocampus") as mock_hippo,
+        patch("episemic.cli.main.Cortex") as mock_cortex,
+        patch("episemic.cli.main.ConsolidationEngine"),
+        patch("episemic.cli.main.RetrievalEngine"),
+    ):
+        result = cli_runner.invoke(
+            app,
+            [
+                "init",
+                "--qdrant-host",
+                "custom-qdrant",
+                "--qdrant-port",
+                "9999",
+                "--postgres-host",
+                "custom-postgres",
+                "--postgres-port",
+                "5433",
+                "--postgres-db",
+                "custom-db",
+            ],
+        )
 
         assert result.exit_code == 0
         mock_hippo.assert_called_once_with("custom-qdrant", 9999)
@@ -112,7 +122,7 @@ def test_init_command_with_custom_params(cli_runner):
 
 def test_init_command_failure(cli_runner):
     """Test init command failure."""
-    with patch('episemic.cli.main.Hippocampus', side_effect=Exception("Init failed")):
+    with patch("episemic.cli.main.Hippocampus", side_effect=Exception("Init failed")):
         result = cli_runner.invoke(app, ["init"])
 
         assert result.exit_code == 1
@@ -122,19 +132,26 @@ def test_init_command_failure(cli_runner):
 def test_store_command_success(cli_runner, mock_memory_system):
     """Test successful store command."""
     # Mock successful storage
-    mock_memory_system['cortex'].store_memory.return_value = True
+    mock_memory_system["cortex"].store_memory.return_value = True
 
-    with patch('asyncio.run') as mock_run:
+    with patch("asyncio.run") as mock_run:
         mock_run.return_value = "test-memory-id"
 
-        result = cli_runner.invoke(app, [
-            "store",
-            "Test memory content",
-            "--title", "Test Title",
-            "--source", "test",
-            "--tags", "test1",
-            "--tags", "test2"
-        ])
+        result = cli_runner.invoke(
+            app,
+            [
+                "store",
+                "Test memory content",
+                "--title",
+                "Test Title",
+                "--source",
+                "test",
+                "--tags",
+                "test1",
+                "--tags",
+                "test2",
+            ],
+        )
 
         assert result.exit_code == 0
         assert "Memory stored with ID: test-memory-id" in result.stdout
@@ -142,15 +159,12 @@ def test_store_command_success(cli_runner, mock_memory_system):
 
 def test_store_command_no_title(cli_runner, mock_memory_system):
     """Test store command without title (should generate from text)."""
-    mock_memory_system['cortex'].store_memory.return_value = True
+    mock_memory_system["cortex"].store_memory.return_value = True
 
-    with patch('asyncio.run') as mock_run:
+    with patch("asyncio.run") as mock_run:
         mock_run.return_value = "test-memory-id"
 
-        result = cli_runner.invoke(app, [
-            "store",
-            "Short text"
-        ])
+        result = cli_runner.invoke(app, ["store", "Short text"])
 
         assert result.exit_code == 0
         assert "Memory stored with ID: test-memory-id" in result.stdout
@@ -158,16 +172,13 @@ def test_store_command_no_title(cli_runner, mock_memory_system):
 
 def test_store_command_long_text(cli_runner, mock_memory_system):
     """Test store command with long text (should truncate title and summary)."""
-    mock_memory_system['cortex'].store_memory.return_value = True
+    mock_memory_system["cortex"].store_memory.return_value = True
     long_text = "A" * 300  # Long text
 
-    with patch('asyncio.run') as mock_run:
+    with patch("asyncio.run") as mock_run:
         mock_run.return_value = "test-memory-id"
 
-        result = cli_runner.invoke(app, [
-            "store",
-            long_text
-        ])
+        result = cli_runner.invoke(app, ["store", long_text])
 
         assert result.exit_code == 0
         assert "Memory stored with ID: test-memory-id" in result.stdout
@@ -175,13 +186,10 @@ def test_store_command_long_text(cli_runner, mock_memory_system):
 
 def test_store_command_failure(cli_runner, mock_memory_system):
     """Test store command failure."""
-    with patch('asyncio.run') as mock_run:
+    with patch("asyncio.run") as mock_run:
         mock_run.return_value = None  # Storage failed
 
-        result = cli_runner.invoke(app, [
-            "store",
-            "Test content"
-        ])
+        result = cli_runner.invoke(app, ["store", "Test content"])
 
         assert result.exit_code == 1
         assert "Failed to store memory" in result.stdout
@@ -189,11 +197,8 @@ def test_store_command_failure(cli_runner, mock_memory_system):
 
 def test_store_command_exception(cli_runner, mock_memory_system):
     """Test store command with exception."""
-    with patch('asyncio.run', side_effect=Exception("Storage error")):
-        result = cli_runner.invoke(app, [
-            "store",
-            "Test content"
-        ])
+    with patch("asyncio.run", side_effect=Exception("Storage error")):
+        result = cli_runner.invoke(app, ["store", "Test content"])
 
         assert result.exit_code == 1
         assert "Error storing memory: Storage error" in result.stdout
@@ -203,21 +208,13 @@ def test_search_command_success(cli_runner, mock_memory_system, sample_memory):
     """Test successful search command."""
     # Create search results
     search_result = SearchResult(
-        memory=sample_memory,
-        score=0.95,
-        provenance={"source": "test"},
-        retrieval_path=["test"]
+        memory=sample_memory, score=0.95, provenance={"source": "test"}, retrieval_path=["test"]
     )
 
-    with patch('asyncio.run') as mock_run:
+    with patch("asyncio.run") as mock_run:
         mock_run.return_value = [search_result]
 
-        result = cli_runner.invoke(app, [
-            "search",
-            "test query",
-            "--top-k", "10",
-            "--tags", "test"
-        ])
+        result = cli_runner.invoke(app, ["search", "test query", "--top-k", "10", "--tags", "test"])
 
         assert result.exit_code == 0
         assert "Search Results for: test query" in result.stdout
@@ -228,21 +225,15 @@ def test_search_command_success(cli_runner, mock_memory_system, sample_memory):
 def test_search_command_with_tags(cli_runner, mock_memory_system, sample_memory):
     """Test search command with multiple tags."""
     search_result = SearchResult(
-        memory=sample_memory,
-        score=0.85,
-        provenance={"source": "test"},
-        retrieval_path=["test"]
+        memory=sample_memory, score=0.85, provenance={"source": "test"}, retrieval_path=["test"]
     )
 
-    with patch('asyncio.run') as mock_run:
+    with patch("asyncio.run") as mock_run:
         mock_run.return_value = [search_result]
 
-        result = cli_runner.invoke(app, [
-            "search",
-            "test query",
-            "--tags", "test1",
-            "--tags", "test2"
-        ])
+        result = cli_runner.invoke(
+            app, ["search", "test query", "--tags", "test1", "--tags", "test2"]
+        )
 
         assert result.exit_code == 0
         assert "Search Results" in result.stdout
@@ -250,13 +241,10 @@ def test_search_command_with_tags(cli_runner, mock_memory_system, sample_memory)
 
 def test_search_command_no_results(cli_runner, mock_memory_system):
     """Test search command with no results."""
-    with patch('asyncio.run') as mock_run:
+    with patch("asyncio.run") as mock_run:
         mock_run.return_value = []  # No results
 
-        result = cli_runner.invoke(app, [
-            "search",
-            "nonexistent query"
-        ])
+        result = cli_runner.invoke(app, ["search", "nonexistent query"])
 
         assert result.exit_code == 0
         assert "No memories found matching your query" in result.stdout
@@ -264,11 +252,8 @@ def test_search_command_no_results(cli_runner, mock_memory_system):
 
 def test_search_command_exception(cli_runner, mock_memory_system):
     """Test search command with exception."""
-    with patch('asyncio.run', side_effect=Exception("Search error")):
-        result = cli_runner.invoke(app, [
-            "search",
-            "test query"
-        ])
+    with patch("asyncio.run", side_effect=Exception("Search error")):
+        result = cli_runner.invoke(app, ["search", "test query"])
 
         assert result.exit_code == 1
         assert "Error searching memories: Search error" in result.stdout
@@ -282,23 +267,17 @@ def test_search_command_long_title(cli_runner, mock_memory_system):
         text="Test content",
         summary="Summary",
         source="test",
-        tags=["tag1", "tag2", "tag3", "tag4", "tag5"]  # Many tags
+        tags=["tag1", "tag2", "tag3", "tag4", "tag5"],  # Many tags
     )
 
     search_result = SearchResult(
-        memory=long_title_memory,
-        score=0.75,
-        provenance={"source": "test"},
-        retrieval_path=["test"]
+        memory=long_title_memory, score=0.75, provenance={"source": "test"}, retrieval_path=["test"]
     )
 
-    with patch('asyncio.run') as mock_run:
+    with patch("asyncio.run") as mock_run:
         mock_run.return_value = [search_result]
 
-        result = cli_runner.invoke(app, [
-            "search",
-            "test query"
-        ])
+        result = cli_runner.invoke(app, ["search", "test query"])
 
         assert result.exit_code == 0
         assert "..." in result.stdout  # Title should be truncated
@@ -306,13 +285,10 @@ def test_search_command_long_title(cli_runner, mock_memory_system):
 
 def test_get_command_success(cli_runner, mock_memory_system, sample_memory):
     """Test successful get command."""
-    with patch('asyncio.run') as mock_run:
+    with patch("asyncio.run") as mock_run:
         mock_run.return_value = sample_memory
 
-        result = cli_runner.invoke(app, [
-            "get",
-            "test-memory-id"
-        ])
+        result = cli_runner.invoke(app, ["get", "test-memory-id"])
 
         assert result.exit_code == 0
         assert "Test Memory" in result.stdout
@@ -323,13 +299,10 @@ def test_get_command_success(cli_runner, mock_memory_system, sample_memory):
 
 def test_get_command_not_found(cli_runner, mock_memory_system):
     """Test get command when memory not found."""
-    with patch('asyncio.run') as mock_run:
+    with patch("asyncio.run") as mock_run:
         mock_run.return_value = None  # Memory not found
 
-        result = cli_runner.invoke(app, [
-            "get",
-            "nonexistent-id"
-        ])
+        result = cli_runner.invoke(app, ["get", "nonexistent-id"])
 
         assert result.exit_code == 1
         assert "Memory nonexistent-id not found" in result.stdout
@@ -337,11 +310,8 @@ def test_get_command_not_found(cli_runner, mock_memory_system):
 
 def test_get_command_exception(cli_runner, mock_memory_system):
     """Test get command with exception."""
-    with patch('asyncio.run', side_effect=Exception("Retrieval error")):
-        result = cli_runner.invoke(app, [
-            "get",
-            "test-memory-id"
-        ])
+    with patch("asyncio.run", side_effect=Exception("Retrieval error")):
+        result = cli_runner.invoke(app, ["get", "test-memory-id"])
 
         assert result.exit_code == 1
         assert "Error retrieving memory: Retrieval error" in result.stdout
@@ -349,13 +319,10 @@ def test_get_command_exception(cli_runner, mock_memory_system):
 
 def test_consolidate_command_auto_success(cli_runner, mock_memory_system):
     """Test successful auto consolidation command."""
-    with patch('asyncio.run') as mock_run:
+    with patch("asyncio.run") as mock_run:
         mock_run.return_value = 5  # 5 memories processed
 
-        result = cli_runner.invoke(app, [
-            "consolidate",
-            "--auto"
-        ])
+        result = cli_runner.invoke(app, ["consolidate", "--auto"])
 
         assert result.exit_code == 0
         assert "Auto-consolidation completed. 5 memories processed" in result.stdout
@@ -363,13 +330,10 @@ def test_consolidate_command_auto_success(cli_runner, mock_memory_system):
 
 def test_consolidate_command_single_success(cli_runner, mock_memory_system):
     """Test successful single memory consolidation."""
-    with patch('asyncio.run') as mock_run:
+    with patch("asyncio.run") as mock_run:
         mock_run.return_value = True  # Consolidation successful
 
-        result = cli_runner.invoke(app, [
-            "consolidate",
-            "--memory-id", "test-memory-id"
-        ])
+        result = cli_runner.invoke(app, ["consolidate", "--memory-id", "test-memory-id"])
 
         assert result.exit_code == 0
         assert "Memory test-memory-id consolidated successfully" in result.stdout
@@ -377,13 +341,10 @@ def test_consolidate_command_single_success(cli_runner, mock_memory_system):
 
 def test_consolidate_command_single_failure(cli_runner, mock_memory_system):
     """Test failed single memory consolidation."""
-    with patch('asyncio.run') as mock_run:
+    with patch("asyncio.run") as mock_run:
         mock_run.return_value = False  # Consolidation failed
 
-        result = cli_runner.invoke(app, [
-            "consolidate",
-            "--memory-id", "test-memory-id"
-        ])
+        result = cli_runner.invoke(app, ["consolidate", "--memory-id", "test-memory-id"])
 
         assert result.exit_code == 1
         assert "Failed to consolidate memory test-memory-id" in result.stdout
@@ -399,11 +360,8 @@ def test_consolidate_command_no_params(cli_runner, mock_memory_system):
 
 def test_consolidate_command_exception(cli_runner, mock_memory_system):
     """Test consolidate command with exception."""
-    with patch('asyncio.run', side_effect=Exception("Consolidation error")):
-        result = cli_runner.invoke(app, [
-            "consolidate",
-            "--auto"
-        ])
+    with patch("asyncio.run", side_effect=Exception("Consolidation error")):
+        result = cli_runner.invoke(app, ["consolidate", "--auto"])
 
         assert result.exit_code == 1
         assert "Error during consolidation: Consolidation error" in result.stdout
@@ -412,18 +370,18 @@ def test_consolidate_command_exception(cli_runner, mock_memory_system):
 def test_health_command_all_healthy(cli_runner, mock_memory_system):
     """Test health command when all components are healthy."""
     # Mock healthy responses
-    mock_memory_system['hippocampus'].health_check.return_value = {
+    mock_memory_system["hippocampus"].health_check.return_value = {
         "qdrant_connected": True,
-        "redis_connected": True
+        "redis_connected": True,
     }
-    mock_memory_system['cortex'].health_check.return_value = True
-    mock_memory_system['consolidation'].health_check.return_value = {
+    mock_memory_system["cortex"].health_check.return_value = True
+    mock_memory_system["consolidation"].health_check.return_value = {
         "hippocampus_healthy": True,
-        "cortex_healthy": True
+        "cortex_healthy": True,
     }
-    mock_memory_system['retrieval'].health_check.return_value = {
+    mock_memory_system["retrieval"].health_check.return_value = {
         "hippocampus_healthy": True,
-        "cortex_healthy": True
+        "cortex_healthy": True,
     }
 
     result = cli_runner.invoke(app, ["health"])
@@ -436,18 +394,18 @@ def test_health_command_all_healthy(cli_runner, mock_memory_system):
 def test_health_command_some_unhealthy(cli_runner, mock_memory_system):
     """Test health command when some components are unhealthy."""
     # Mock mixed health responses
-    mock_memory_system['hippocampus'].health_check.return_value = {
+    mock_memory_system["hippocampus"].health_check.return_value = {
         "qdrant_connected": False,  # Unhealthy
-        "redis_connected": True
+        "redis_connected": True,
     }
-    mock_memory_system['cortex'].health_check.return_value = True
-    mock_memory_system['consolidation'].health_check.return_value = {
+    mock_memory_system["cortex"].health_check.return_value = True
+    mock_memory_system["consolidation"].health_check.return_value = {
         "hippocampus_healthy": False,  # Unhealthy
-        "cortex_healthy": True
+        "cortex_healthy": True,
     }
-    mock_memory_system['retrieval'].health_check.return_value = {
+    mock_memory_system["retrieval"].health_check.return_value = {
         "hippocampus_healthy": True,
-        "cortex_healthy": True
+        "cortex_healthy": True,
     }
 
     result = cli_runner.invoke(app, ["health"])
@@ -460,7 +418,7 @@ def test_health_command_some_unhealthy(cli_runner, mock_memory_system):
 
 def test_health_command_exception(cli_runner, mock_memory_system):
     """Test health command with exception."""
-    mock_memory_system['hippocampus'].health_check.side_effect = Exception("Health check error")
+    mock_memory_system["hippocampus"].health_check.side_effect = Exception("Health check error")
 
     result = cli_runner.invoke(app, ["health"])
 
@@ -470,19 +428,22 @@ def test_health_command_exception(cli_runner, mock_memory_system):
 
 def test_get_memory_system_initialization():
     """Test get_memory_system function initializes components."""
-    with patch('episemic.cli.main.Hippocampus') as mock_hippo, \
-         patch('episemic.cli.main.Cortex') as mock_cortex, \
-         patch('episemic.cli.main.ConsolidationEngine') as mock_consol, \
-         patch('episemic.cli.main.RetrievalEngine') as mock_retrieval:
-
+    with (
+        patch("episemic.cli.main.Hippocampus") as mock_hippo,
+        patch("episemic.cli.main.Cortex") as mock_cortex,
+        patch("episemic.cli.main.ConsolidationEngine") as mock_consol,
+        patch("episemic.cli.main.RetrievalEngine") as mock_retrieval,
+    ):
         # Clear global instances
         import episemic.cli.main as cli_main
+
         cli_main.hippocampus = None
         cli_main.cortex = None
         cli_main.consolidation_engine = None
         cli_main.retrieval_engine = None
 
         from episemic.cli.main import get_memory_system
+
         hippo, cortex, consol, retrieval = get_memory_system()
 
         # Verify components were created
@@ -494,19 +455,22 @@ def test_get_memory_system_initialization():
 
 def test_get_memory_system_reuse_existing():
     """Test get_memory_system reuses existing components."""
-    with patch('episemic.cli.main.Hippocampus') as mock_hippo, \
-         patch('episemic.cli.main.Cortex') as mock_cortex, \
-         patch('episemic.cli.main.ConsolidationEngine') as mock_consol, \
-         patch('episemic.cli.main.RetrievalEngine') as mock_retrieval:
-
+    with (
+        patch("episemic.cli.main.Hippocampus") as mock_hippo,
+        patch("episemic.cli.main.Cortex") as mock_cortex,
+        patch("episemic.cli.main.ConsolidationEngine") as mock_consol,
+        patch("episemic.cli.main.RetrievalEngine") as mock_retrieval,
+    ):
         # Set global instances
         import episemic.cli.main as cli_main
+
         cli_main.hippocampus = "existing_hippo"
         cli_main.cortex = "existing_cortex"
         cli_main.consolidation_engine = "existing_consol"
         cli_main.retrieval_engine = "existing_retrieval"
 
         from episemic.cli.main import get_memory_system
+
         hippo, cortex, consol, retrieval = get_memory_system()
 
         # Verify existing components were returned
@@ -530,26 +494,26 @@ def test_command_help_individual():
     for command in commands:
         result = cli_runner.invoke(app, [command, "--help"])
         assert result.exit_code == 0
-        assert ("Usage:" in result.stdout or "Show this message" in result.stdout)
+        assert "Usage:" in result.stdout or "Show this message" in result.stdout
 
 
 def test_consolidate_complex_health_check_logic(cli_runner, mock_memory_system):
     """Test health command with complex health check responses."""
     # Mock complex health responses
-    mock_memory_system['hippocampus'].health_check.return_value = {
+    mock_memory_system["hippocampus"].health_check.return_value = {
         "qdrant_connected": True,
         "redis_connected": True,
-        "extra_field": "should_be_ignored"
+        "extra_field": "should_be_ignored",
     }
-    mock_memory_system['cortex'].health_check.return_value = True
-    mock_memory_system['consolidation'].health_check.return_value = {
+    mock_memory_system["cortex"].health_check.return_value = True
+    mock_memory_system["consolidation"].health_check.return_value = {
         "hippocampus_healthy": {"nested": "dict"},  # Dict instead of bool
         "cortex_healthy": True,
-        "extra_field": "not_a_bool"
+        "extra_field": "not_a_bool",
     }
-    mock_memory_system['retrieval'].health_check.return_value = {
+    mock_memory_system["retrieval"].health_check.return_value = {
         "hippocampus_healthy": True,
-        "cortex_healthy": {"another": "dict"}  # Dict instead of bool
+        "cortex_healthy": {"another": "dict"},  # Dict instead of bool
     }
 
     result = cli_runner.invoke(app, ["health"])
@@ -560,7 +524,7 @@ def test_consolidate_complex_health_check_logic(cli_runner, mock_memory_system):
 
 def test_store_command_memory_creation_logic(cli_runner, mock_memory_system):
     """Test store command memory creation with different text lengths."""
-    mock_memory_system['cortex'].store_memory.return_value = True
+    mock_memory_system["cortex"].store_memory.return_value = True
 
     test_cases = [
         # (text, expected_title_contains, expected_summary_contains)
@@ -571,7 +535,7 @@ def test_store_command_memory_creation_logic(cli_runner, mock_memory_system):
     ]
 
     for text, _, _ in test_cases:
-        with patch('asyncio.run') as mock_run:
+        with patch("asyncio.run") as mock_run:
             mock_run.return_value = "test-id"
 
             result = cli_runner.invoke(app, ["store", text])
@@ -588,7 +552,7 @@ def test_search_results_display_formatting(cli_runner, mock_memory_system):
             text="Content",
             summary="Summary",
             source="test",
-            tags=["tag1"]
+            tags=["tag1"],
         ),
         Memory(
             id="very-long-memory-id-that-should-be-truncated",
@@ -596,7 +560,7 @@ def test_search_results_display_formatting(cli_runner, mock_memory_system):
             text="Content",
             summary="Summary",
             source="test",
-            tags=["tag1", "tag2", "tag3", "tag4", "tag5", "tag6"]  # Many tags
+            tags=["tag1", "tag2", "tag3", "tag4", "tag5", "tag6"],  # Many tags
         ),
         Memory(
             id="no-tags-memory",
@@ -604,16 +568,16 @@ def test_search_results_display_formatting(cli_runner, mock_memory_system):
             text="Content",
             summary="Summary",
             source="test",
-            tags=[]  # No tags
-        )
+            tags=[],  # No tags
+        ),
     ]
 
     search_results = [
-        SearchResult(memory=mem, score=0.8 - i*0.1, provenance={}, retrieval_path=[])
+        SearchResult(memory=mem, score=0.8 - i * 0.1, provenance={}, retrieval_path=[])
         for i, mem in enumerate(memories)
     ]
 
-    with patch('asyncio.run') as mock_run:
+    with patch("asyncio.run") as mock_run:
         mock_run.return_value = search_results
 
         result = cli_runner.invoke(app, ["search", "test"])
@@ -632,10 +596,10 @@ def test_memory_display_formatting_in_get(cli_runner, mock_memory_system):
         source="comprehensive_test",
         tags=["tag1", "tag2", "tag3"],
         created_at=datetime(2023, 1, 1, 12, 0, 0),
-        access_count=42
+        access_count=42,
     )
 
-    with patch('asyncio.run') as mock_run:
+    with patch("asyncio.run") as mock_run:
         mock_run.return_value = memory_with_all_fields
 
         result = cli_runner.invoke(app, ["get", "full-memory-id"])
@@ -650,7 +614,7 @@ def test_memory_display_formatting_in_get(cli_runner, mock_memory_system):
 
 def test_main_entry_point():
     """Test main entry point."""
-    with patch('episemic.cli.main.app') as mock_app:
+    with patch("episemic.cli.main.app") as mock_app:
         from episemic.cli.main import __name__ as module_name
 
         # Simulate running as main module

--- a/tests/test_config_comprehensive.py
+++ b/tests/test_config_comprehensive.py
@@ -11,7 +11,7 @@ from episemic.config import (
     DuckDBConfig,
     PostgreSQLConfig,
     RedisConfig,
-    ConsolidationConfig
+    ConsolidationConfig,
 )
 
 
@@ -25,10 +25,7 @@ def test_qdrant_config():
 
     # Test custom values
     custom_config = QdrantConfig(
-        host="custom-host",
-        port=6334,
-        collection_name="custom_collection",
-        vector_size=512
+        host="custom-host", port=6334, collection_name="custom_collection", vector_size=512
     )
     assert custom_config.host == "custom-host"
     assert custom_config.port == 6334
@@ -43,10 +40,7 @@ def test_duckdb_config():
     assert config.model_name == "all-MiniLM-L6-v2"
 
     # Test custom values
-    custom_config = DuckDBConfig(
-        db_path="/tmp/test.db",
-        model_name="custom-model"
-    )
+    custom_config = DuckDBConfig(db_path="/tmp/test.db", model_name="custom-model")
     assert custom_config.db_path == "/tmp/test.db"
     assert custom_config.model_name == "custom-model"
 
@@ -62,11 +56,7 @@ def test_postgresql_config():
 
     # Test custom values
     custom_config = PostgreSQLConfig(
-        host="pg-host",
-        port=5433,
-        database="custom_db",
-        user="custom_user",
-        password="custom_pass"
+        host="pg-host", port=5433, database="custom_db", user="custom_user", password="custom_pass"
     )
     assert custom_config.host == "pg-host"
     assert custom_config.port == 5433
@@ -84,12 +74,7 @@ def test_redis_config():
     assert config.ttl == 3600
 
     # Test custom values
-    custom_config = RedisConfig(
-        host="redis-host",
-        port=6380,
-        db=1,
-        ttl=7200
-    )
+    custom_config = RedisConfig(host="redis-host", port=6380, db=1, ttl=7200)
     assert custom_config.host == "redis-host"
     assert custom_config.port == 6380
     assert custom_config.db == 1
@@ -109,7 +94,7 @@ def test_consolidation_config():
         threshold_hours=4,
         access_threshold=5,
         auto_consolidation_enabled=False,
-        consolidation_interval_minutes=120
+        consolidation_interval_minutes=120,
     )
     assert custom_config.threshold_hours == 4
     assert custom_config.access_threshold == 5
@@ -146,22 +131,13 @@ def test_episemic_config_defaults():
 def test_episemic_config_from_dict():
     """Test EpistemicConfig.from_dict functionality."""
     config_dict = {
-        "qdrant": {
-            "host": "custom-qdrant",
-            "port": 6334
-        },
-        "duckdb": {
-            "db_path": "/tmp/custom.db",
-            "model_name": "custom-model"
-        },
-        "postgresql": {
-            "host": "custom-pg",
-            "database": "custom_db"
-        },
+        "qdrant": {"host": "custom-qdrant", "port": 6334},
+        "duckdb": {"db_path": "/tmp/custom.db", "model_name": "custom-model"},
+        "postgresql": {"host": "custom-pg", "database": "custom_db"},
         "use_duckdb_fallback": False,
         "prefer_qdrant": True,
         "debug": True,
-        "log_level": "DEBUG"
+        "log_level": "DEBUG",
     }
 
     config = EpistemicConfig.from_dict(config_dict)
@@ -203,30 +179,25 @@ def test_episemic_config_from_env_complete():
         "QDRANT_HOST": "env-qdrant-host",
         "QDRANT_PORT": "6334",
         "QDRANT_COLLECTION": "env_collection",
-
         # DuckDB settings
         "DUCKDB_PATH": "/env/path/test.db",
         "DUCKDB_MODEL": "env-model",
-
         # Storage backend preferences
         "EPISEMIC_USE_DUCKDB": "false",
         "EPISEMIC_PREFER_QDRANT": "true",
-
         # PostgreSQL settings
         "POSTGRES_HOST": "env-pg-host",
         "POSTGRES_PORT": "5433",
         "POSTGRES_DB": "env_db",
         "POSTGRES_USER": "env_user",
         "POSTGRES_PASSWORD": "env_pass",
-
         # Redis settings
         "REDIS_HOST": "env-redis-host",
         "REDIS_PORT": "6380",
         "REDIS_DB": "2",
-
         # Debug settings
         "EPISEMIC_DEBUG": "true",
-        "EPISEMIC_LOG_LEVEL": "DEBUG"
+        "EPISEMIC_LOG_LEVEL": "DEBUG",
     }
 
     with patch.dict(os.environ, env_vars, clear=False):
@@ -309,12 +280,23 @@ def test_episemic_config_from_env_no_env_vars():
     """Test EpistemicConfig.from_env when no environment variables are set."""
     # Clear relevant environment variables
     env_vars_to_clear = [
-        "QDRANT_HOST", "QDRANT_PORT", "QDRANT_COLLECTION",
-        "DUCKDB_PATH", "DUCKDB_MODEL",
-        "EPISEMIC_USE_DUCKDB", "EPISEMIC_PREFER_QDRANT",
-        "POSTGRES_HOST", "POSTGRES_PORT", "POSTGRES_DB", "POSTGRES_USER", "POSTGRES_PASSWORD",
-        "REDIS_HOST", "REDIS_PORT", "REDIS_DB",
-        "EPISEMIC_DEBUG", "EPISEMIC_LOG_LEVEL"
+        "QDRANT_HOST",
+        "QDRANT_PORT",
+        "QDRANT_COLLECTION",
+        "DUCKDB_PATH",
+        "DUCKDB_MODEL",
+        "EPISEMIC_USE_DUCKDB",
+        "EPISEMIC_PREFER_QDRANT",
+        "POSTGRES_HOST",
+        "POSTGRES_PORT",
+        "POSTGRES_DB",
+        "POSTGRES_USER",
+        "POSTGRES_PASSWORD",
+        "REDIS_HOST",
+        "REDIS_PORT",
+        "REDIS_DB",
+        "EPISEMIC_DEBUG",
+        "EPISEMIC_LOG_LEVEL",
     ]
 
     # Backup existing values
@@ -349,7 +331,7 @@ def test_episemic_config_from_env_integer_conversion():
         "QDRANT_PORT": "6334",
         "POSTGRES_PORT": "5433",
         "REDIS_PORT": "6380",
-        "REDIS_DB": "3"
+        "REDIS_DB": "3",
     }
 
     with patch.dict(os.environ, env_vars, clear=False):
@@ -369,7 +351,7 @@ def test_episemic_config_custom_initialization():
         enable_cortex=False,
         enable_consolidation=False,
         debug=True,
-        log_level="WARNING"
+        log_level="WARNING",
     )
 
     assert config.use_duckdb_fallback is False

--- a/tests/test_cortex_comprehensive.py
+++ b/tests/test_cortex_comprehensive.py
@@ -12,7 +12,7 @@ from episemic.models import Memory, MemoryLink, LinkType, MemoryStatus, Retentio
 @pytest.fixture
 def mock_psycopg2():
     """Mock psycopg2 and its connection/cursor objects."""
-    with patch('episemic.cortex.cortex.psycopg2') as mock_pg:
+    with patch("episemic.cortex.cortex.psycopg2") as mock_pg:
         # Mock connection and cursor
         mock_conn = MagicMock()
         mock_cursor = MagicMock()
@@ -29,11 +29,7 @@ def mock_psycopg2():
         mock_conn.cursor.return_value = mock_cursor
         mock_pg.connect.return_value = mock_conn
 
-        yield {
-            'psycopg2': mock_pg,
-            'connection': mock_conn,
-            'cursor': mock_cursor
-        }
+        yield {"psycopg2": mock_pg, "connection": mock_conn, "cursor": mock_cursor}
 
 
 @pytest.fixture
@@ -44,7 +40,7 @@ def cortex(mock_psycopg2):
         db_port=5432,
         db_name="test_db",
         db_user="test_user",
-        db_password="test_password"
+        db_password="test_password",
     )
 
 
@@ -59,13 +55,7 @@ def sample_memory():
         source="test",
         tags=["test", "memory"],
         metadata={"category": "test"},
-        links=[
-            MemoryLink(
-                target_id="linked-memory-id",
-                type=LinkType.CITES,
-                weight=0.8
-            )
-        ]
+        links=[MemoryLink(target_id="linked-memory-id", type=LinkType.CITES, weight=0.8)],
     )
 
 
@@ -76,7 +66,7 @@ def test_cortex_initialization(mock_psycopg2):
         db_port=5432,
         db_name="episemic",
         db_user="postgres",
-        db_password="postgres"
+        db_password="postgres",
     )
 
     # Verify connection parameters
@@ -85,12 +75,12 @@ def test_cortex_initialization(mock_psycopg2):
         "port": 5432,
         "database": "episemic",
         "user": "postgres",
-        "password": "postgres"
+        "password": "postgres",
     }
 
     # Verify database setup was called
-    mock_psycopg2['psycopg2'].connect.assert_called()
-    mock_psycopg2['cursor'].execute.assert_called()
+    mock_psycopg2["psycopg2"].connect.assert_called()
+    mock_psycopg2["cursor"].execute.assert_called()
 
 
 def test_cortex_initialization_custom_params(mock_psycopg2):
@@ -100,7 +90,7 @@ def test_cortex_initialization_custom_params(mock_psycopg2):
         db_port=5433,
         db_name="custom-db",
         db_user="custom-user",
-        db_password="custom-pass"
+        db_password="custom-pass",
     )
 
     expected_params = {
@@ -108,7 +98,7 @@ def test_cortex_initialization_custom_params(mock_psycopg2):
         "port": 5433,
         "database": "custom-db",
         "user": "custom-user",
-        "password": "custom-pass"
+        "password": "custom-pass",
     }
 
     assert cortex.connection_params == expected_params
@@ -118,8 +108,8 @@ def test_get_connection(cortex, mock_psycopg2):
     """Test _get_connection method."""
     conn = cortex._get_connection()
 
-    mock_psycopg2['psycopg2'].connect.assert_called_with(**cortex.connection_params)
-    assert conn == mock_psycopg2['connection']
+    mock_psycopg2["psycopg2"].connect.assert_called_with(**cortex.connection_params)
+    assert conn == mock_psycopg2["connection"]
 
 
 @pytest.mark.asyncio
@@ -130,7 +120,7 @@ async def test_store_memory_success(cortex, mock_psycopg2, sample_memory):
     assert result is True
 
     # Verify main memory insert was called
-    calls = mock_psycopg2['cursor'].execute.call_args_list
+    calls = mock_psycopg2["cursor"].execute.call_args_list
 
     # Check that memory insert was called
     memory_insert_call = None
@@ -142,7 +132,7 @@ async def test_store_memory_success(cortex, mock_psycopg2, sample_memory):
     assert memory_insert_call is not None
 
     # Verify commit was called
-    mock_psycopg2['connection'].commit.assert_called()
+    mock_psycopg2["connection"].commit.assert_called()
 
 
 @pytest.mark.asyncio
@@ -153,7 +143,7 @@ async def test_store_memory_with_links(cortex, mock_psycopg2, sample_memory):
     assert result is True
 
     # Verify link insert was called
-    calls = mock_psycopg2['cursor'].execute.call_args_list
+    calls = mock_psycopg2["cursor"].execute.call_args_list
     link_insert_call = None
     for call in calls:
         if "INSERT INTO memory_links" in str(call):
@@ -167,17 +157,17 @@ async def test_store_memory_with_links(cortex, mock_psycopg2, sample_memory):
 async def test_store_memory_exception_handling(cortex, mock_psycopg2):
     """Test memory storage exception handling."""
     # Make execute raise an exception
-    mock_psycopg2['cursor'].execute.side_effect = Exception("Database error")
+    mock_psycopg2["cursor"].execute.side_effect = Exception("Database error")
 
     memory = Memory(
         id="error-memory",
         title="Error Memory",
         text="Error content",
         summary="Error summary",
-        source="test"
+        source="test",
     )
 
-    with patch('builtins.print') as mock_print:
+    with patch("builtins.print") as mock_print:
         result = await cortex.store_memory(memory)
 
     assert result is False
@@ -189,39 +179,33 @@ async def test_retrieve_memory_success(cortex, mock_psycopg2):
     """Test successful memory retrieval."""
     # Mock database row
     mock_row = {
-        'id': 'test-memory-id',
-        'title': 'Test Memory',
-        'text': 'Test content',
-        'summary': 'Test summary',
-        'source': 'test',
-        'source_ref': None,
-        'tags': ['test'],
-        'metadata': {},
-        'created_at': datetime.utcnow(),
-        'ingested_at': datetime.utcnow(),
-        'hash': 'test-hash',
-        'version': 1,
-        'access_count': 0,
-        'last_accessed': None,
-        'retention_policy': 'default',
-        'status': 'active',
-        'checksum_status': 'unknown',
-        'embedding_v1': None,
-        'embedding_v2': None
+        "id": "test-memory-id",
+        "title": "Test Memory",
+        "text": "Test content",
+        "summary": "Test summary",
+        "source": "test",
+        "source_ref": None,
+        "tags": ["test"],
+        "metadata": {},
+        "created_at": datetime.utcnow(),
+        "ingested_at": datetime.utcnow(),
+        "hash": "test-hash",
+        "version": 1,
+        "access_count": 0,
+        "last_accessed": None,
+        "retention_policy": "default",
+        "status": "active",
+        "checksum_status": "unknown",
+        "embedding_v1": None,
+        "embedding_v2": None,
     }
 
     # Mock links
-    mock_links = [
-        {
-            'target_id': 'linked-memory',
-            'link_type': 'cites',
-            'weight': 0.8
-        }
-    ]
+    mock_links = [{"target_id": "linked-memory", "link_type": "cites", "weight": 0.8}]
 
     # Setup cursor to return our mock data
-    mock_psycopg2['cursor'].fetchone.return_value = mock_row
-    mock_psycopg2['cursor'].fetchall.return_value = mock_links
+    mock_psycopg2["cursor"].fetchone.return_value = mock_row
+    mock_psycopg2["cursor"].fetchall.return_value = mock_links
 
     result = await cortex.retrieve_memory("test-memory-id")
 
@@ -235,7 +219,7 @@ async def test_retrieve_memory_success(cortex, mock_psycopg2):
 @pytest.mark.asyncio
 async def test_retrieve_memory_not_found(cortex, mock_psycopg2):
     """Test memory retrieval when memory not found."""
-    mock_psycopg2['cursor'].fetchone.return_value = None
+    mock_psycopg2["cursor"].fetchone.return_value = None
 
     result = await cortex.retrieve_memory("nonexistent-id")
 
@@ -245,9 +229,9 @@ async def test_retrieve_memory_not_found(cortex, mock_psycopg2):
 @pytest.mark.asyncio
 async def test_retrieve_memory_exception_handling(cortex, mock_psycopg2):
     """Test memory retrieval exception handling."""
-    mock_psycopg2['cursor'].execute.side_effect = Exception("Retrieval error")
+    mock_psycopg2["cursor"].execute.side_effect = Exception("Retrieval error")
 
-    with patch('builtins.print') as mock_print:
+    with patch("builtins.print") as mock_print:
         result = await cortex.retrieve_memory("error-memory")
 
     assert result is None
@@ -260,50 +244,50 @@ async def test_search_by_tags_success(cortex, mock_psycopg2):
     # Mock search results
     mock_rows = [
         {
-            'id': 'memory1',
-            'title': 'Memory 1',
-            'text': 'Content 1',
-            'summary': 'Summary 1',
-            'source': 'test',
-            'source_ref': None,
-            'tags': ['python', 'programming'],
-            'metadata': {},
-            'created_at': datetime.utcnow(),
-            'ingested_at': datetime.utcnow(),
-            'hash': 'hash1',
-            'version': 1,
-            'access_count': 0,
-            'last_accessed': None,
-            'retention_policy': 'default',
-            'status': 'active',
-            'checksum_status': 'unknown',
-            'embedding_v1': None,
-            'embedding_v2': None
+            "id": "memory1",
+            "title": "Memory 1",
+            "text": "Content 1",
+            "summary": "Summary 1",
+            "source": "test",
+            "source_ref": None,
+            "tags": ["python", "programming"],
+            "metadata": {},
+            "created_at": datetime.utcnow(),
+            "ingested_at": datetime.utcnow(),
+            "hash": "hash1",
+            "version": 1,
+            "access_count": 0,
+            "last_accessed": None,
+            "retention_policy": "default",
+            "status": "active",
+            "checksum_status": "unknown",
+            "embedding_v1": None,
+            "embedding_v2": None,
         },
         {
-            'id': 'memory2',
-            'title': 'Memory 2',
-            'text': 'Content 2',
-            'summary': 'Summary 2',
-            'source': 'test',
-            'source_ref': None,
-            'tags': ['python', 'tutorial'],
-            'metadata': {},
-            'created_at': datetime.utcnow(),
-            'ingested_at': datetime.utcnow(),
-            'hash': 'hash2',
-            'version': 1,
-            'access_count': 0,
-            'last_accessed': None,
-            'retention_policy': 'default',
-            'status': 'active',
-            'checksum_status': 'unknown',
-            'embedding_v1': None,
-            'embedding_v2': None
-        }
+            "id": "memory2",
+            "title": "Memory 2",
+            "text": "Content 2",
+            "summary": "Summary 2",
+            "source": "test",
+            "source_ref": None,
+            "tags": ["python", "tutorial"],
+            "metadata": {},
+            "created_at": datetime.utcnow(),
+            "ingested_at": datetime.utcnow(),
+            "hash": "hash2",
+            "version": 1,
+            "access_count": 0,
+            "last_accessed": None,
+            "retention_policy": "default",
+            "status": "active",
+            "checksum_status": "unknown",
+            "embedding_v1": None,
+            "embedding_v2": None,
+        },
     ]
 
-    mock_psycopg2['cursor'].fetchall.return_value = mock_rows
+    mock_psycopg2["cursor"].fetchall.return_value = mock_rows
 
     results = await cortex.search_by_tags(["python"], limit=10)
 
@@ -317,7 +301,7 @@ async def test_search_by_tags_success(cortex, mock_psycopg2):
 @pytest.mark.asyncio
 async def test_search_by_tags_empty_results(cortex, mock_psycopg2):
     """Test tag search with no results."""
-    mock_psycopg2['cursor'].fetchall.return_value = []
+    mock_psycopg2["cursor"].fetchall.return_value = []
 
     results = await cortex.search_by_tags(["nonexistent"], limit=10)
 
@@ -327,9 +311,9 @@ async def test_search_by_tags_empty_results(cortex, mock_psycopg2):
 @pytest.mark.asyncio
 async def test_search_by_tags_exception_handling(cortex, mock_psycopg2):
     """Test tag search exception handling."""
-    mock_psycopg2['cursor'].execute.side_effect = Exception("Search error")
+    mock_psycopg2["cursor"].execute.side_effect = Exception("Search error")
 
-    with patch('builtins.print') as mock_print:
+    with patch("builtins.print") as mock_print:
         results = await cortex.search_by_tags(["test"])
 
     assert results == []
@@ -341,21 +325,14 @@ async def test_get_memory_graph_success(cortex, mock_psycopg2):
     """Test successful memory graph retrieval."""
     # Mock nodes and edges
     mock_nodes = [
-        {'id': 'node1', 'title': 'Node 1', 'depth': 0},
-        {'id': 'node2', 'title': 'Node 2', 'depth': 1}
+        {"id": "node1", "title": "Node 1", "depth": 0},
+        {"id": "node2", "title": "Node 2", "depth": 1},
     ]
 
-    mock_edges = [
-        {
-            'source_id': 'node1',
-            'target_id': 'node2',
-            'link_type': 'cites',
-            'weight': 0.8
-        }
-    ]
+    mock_edges = [{"source_id": "node1", "target_id": "node2", "link_type": "cites", "weight": 0.8}]
 
     # Setup cursor to return nodes first, then edges
-    mock_psycopg2['cursor'].fetchall.side_effect = [mock_nodes, mock_edges]
+    mock_psycopg2["cursor"].fetchall.side_effect = [mock_nodes, mock_edges]
 
     result = await cortex.get_memory_graph("node1", depth=2)
 
@@ -370,9 +347,9 @@ async def test_get_memory_graph_success(cortex, mock_psycopg2):
 @pytest.mark.asyncio
 async def test_get_memory_graph_exception_handling(cortex, mock_psycopg2):
     """Test memory graph exception handling."""
-    mock_psycopg2['cursor'].execute.side_effect = Exception("Graph error")
+    mock_psycopg2["cursor"].execute.side_effect = Exception("Graph error")
 
-    with patch('builtins.print') as mock_print:
+    with patch("builtins.print") as mock_print:
         result = await cortex.get_memory_graph("error-node")
 
     assert result == {"nodes": [], "edges": []}
@@ -385,11 +362,11 @@ async def test_increment_access_count_success(cortex, mock_psycopg2):
     await cortex.increment_access_count("test-memory-id")
 
     # Verify the UPDATE query was called
-    mock_psycopg2['cursor'].execute.assert_called()
-    mock_psycopg2['connection'].commit.assert_called()
+    mock_psycopg2["cursor"].execute.assert_called()
+    mock_psycopg2["connection"].commit.assert_called()
 
     # Check the SQL query
-    calls = mock_psycopg2['cursor'].execute.call_args_list
+    calls = mock_psycopg2["cursor"].execute.call_args_list
     update_call = None
     for call in calls:
         if "UPDATE memories" in str(call):
@@ -402,9 +379,9 @@ async def test_increment_access_count_success(cortex, mock_psycopg2):
 @pytest.mark.asyncio
 async def test_increment_access_count_exception_handling(cortex, mock_psycopg2):
     """Test access count increment exception handling."""
-    mock_psycopg2['cursor'].execute.side_effect = Exception("Update error")
+    mock_psycopg2["cursor"].execute.side_effect = Exception("Update error")
 
-    with patch('builtins.print') as mock_print:
+    with patch("builtins.print") as mock_print:
         await cortex.increment_access_count("error-memory")
 
     mock_print.assert_called_with("Error incrementing access count: Update error")
@@ -416,16 +393,16 @@ async def test_mark_deleted_success(cortex, mock_psycopg2):
     await cortex.mark_deleted("test-memory-id")
 
     # Verify the UPDATE query was called
-    mock_psycopg2['cursor'].execute.assert_called()
-    mock_psycopg2['connection'].commit.assert_called()
+    mock_psycopg2["cursor"].execute.assert_called()
+    mock_psycopg2["connection"].commit.assert_called()
 
 
 @pytest.mark.asyncio
 async def test_mark_deleted_exception_handling(cortex, mock_psycopg2):
     """Test memory deletion marking exception handling."""
-    mock_psycopg2['cursor'].execute.side_effect = Exception("Delete error")
+    mock_psycopg2["cursor"].execute.side_effect = Exception("Delete error")
 
-    with patch('builtins.print') as mock_print:
+    with patch("builtins.print") as mock_print:
         await cortex.mark_deleted("error-memory")
 
     mock_print.assert_called_with("Error marking memory as deleted: Delete error")
@@ -433,17 +410,17 @@ async def test_mark_deleted_exception_handling(cortex, mock_psycopg2):
 
 def test_health_check_success(cortex, mock_psycopg2):
     """Test successful health check."""
-    mock_psycopg2['cursor'].fetchone.return_value = (1,)
+    mock_psycopg2["cursor"].fetchone.return_value = (1,)
 
     result = cortex.health_check()
 
     assert result is True
-    mock_psycopg2['cursor'].execute.assert_called_with("SELECT 1")
+    mock_psycopg2["cursor"].execute.assert_called_with("SELECT 1")
 
 
 def test_health_check_failure(cortex, mock_psycopg2):
     """Test health check failure."""
-    mock_psycopg2['cursor'].fetchone.return_value = None
+    mock_psycopg2["cursor"].fetchone.return_value = None
 
     result = cortex.health_check()
 
@@ -452,7 +429,7 @@ def test_health_check_failure(cortex, mock_psycopg2):
 
 def test_health_check_exception_handling(cortex, mock_psycopg2):
     """Test health check exception handling."""
-    mock_psycopg2['psycopg2'].connect.side_effect = Exception("Connection error")
+    mock_psycopg2["psycopg2"].connect.side_effect = Exception("Connection error")
 
     result = cortex.health_check()
 
@@ -464,10 +441,10 @@ def test_database_setup_table_creation(mock_psycopg2):
     cortex = Cortex()
 
     # Check that execute was called multiple times for table creation
-    assert mock_psycopg2['cursor'].execute.call_count >= 3
+    assert mock_psycopg2["cursor"].execute.call_count >= 3
 
     # Verify commit was called
-    mock_psycopg2['connection'].commit.assert_called()
+    mock_psycopg2["connection"].commit.assert_called()
 
 
 @pytest.mark.asyncio
@@ -479,11 +456,7 @@ async def test_store_memory_with_complex_metadata(cortex, mock_psycopg2):
         text="Complex content",
         summary="Complex summary",
         source="test",
-        metadata={
-            "nested": {"key": "value"},
-            "list": [1, 2, 3],
-            "string": "test"
-        }
+        metadata={"nested": {"key": "value"}, "list": [1, 2, 3], "string": "test"},
     )
 
     result = await cortex.store_memory(memory)
@@ -491,7 +464,7 @@ async def test_store_memory_with_complex_metadata(cortex, mock_psycopg2):
     assert result is True
 
     # Verify that the metadata was JSON serialized in the call
-    calls = mock_psycopg2['cursor'].execute.call_args_list
+    calls = mock_psycopg2["cursor"].execute.call_args_list
     memory_insert_call = None
     for call in calls:
         if "INSERT INTO memories" in str(call):
@@ -509,12 +482,12 @@ async def test_store_memory_with_complex_metadata(cortex, mock_psycopg2):
 @pytest.mark.asyncio
 async def test_search_by_tags_with_custom_limit(cortex, mock_psycopg2):
     """Test tag search with custom limit."""
-    mock_psycopg2['cursor'].fetchall.return_value = []
+    mock_psycopg2["cursor"].fetchall.return_value = []
 
     await cortex.search_by_tags(["test"], limit=5)
 
     # Verify the limit was passed to the query
-    call_args = mock_psycopg2['cursor'].execute.call_args
+    call_args = mock_psycopg2["cursor"].execute.call_args
     assert call_args[0][1] == (["test"], 5)
 
 
@@ -525,7 +498,7 @@ def test_cortex_connection_parameters_validation(mock_psycopg2):
         db_port=9999,
         db_name="test-database",
         db_user="test-user",
-        db_password="secret-password"
+        db_password="secret-password",
     )
 
     expected_params = {
@@ -533,7 +506,7 @@ def test_cortex_connection_parameters_validation(mock_psycopg2):
         "port": 9999,
         "database": "test-database",
         "user": "test-user",
-        "password": "secret-password"
+        "password": "secret-password",
     }
 
     assert cortex.connection_params == expected_params
@@ -544,30 +517,30 @@ async def test_memory_retrieval_with_no_links(cortex, mock_psycopg2):
     """Test memory retrieval when memory has no links."""
     # Mock database row
     mock_row = {
-        'id': 'no-links-memory',
-        'title': 'No Links Memory',
-        'text': 'Content without links',
-        'summary': 'Summary',
-        'source': 'test',
-        'source_ref': None,
-        'tags': ['test'],
-        'metadata': {},
-        'created_at': datetime.utcnow(),
-        'ingested_at': datetime.utcnow(),
-        'hash': 'test-hash',
-        'version': 1,
-        'access_count': 0,
-        'last_accessed': None,
-        'retention_policy': 'default',
-        'status': 'active',
-        'checksum_status': 'unknown',
-        'embedding_v1': None,
-        'embedding_v2': None
+        "id": "no-links-memory",
+        "title": "No Links Memory",
+        "text": "Content without links",
+        "summary": "Summary",
+        "source": "test",
+        "source_ref": None,
+        "tags": ["test"],
+        "metadata": {},
+        "created_at": datetime.utcnow(),
+        "ingested_at": datetime.utcnow(),
+        "hash": "test-hash",
+        "version": 1,
+        "access_count": 0,
+        "last_accessed": None,
+        "retention_policy": "default",
+        "status": "active",
+        "checksum_status": "unknown",
+        "embedding_v1": None,
+        "embedding_v2": None,
     }
 
     # Setup cursor to return memory but no links
-    mock_psycopg2['cursor'].fetchone.return_value = mock_row
-    mock_psycopg2['cursor'].fetchall.return_value = []  # No links
+    mock_psycopg2["cursor"].fetchone.return_value = mock_row
+    mock_psycopg2["cursor"].fetchall.return_value = []  # No links
 
     result = await cortex.retrieve_memory("no-links-memory")
 
@@ -579,13 +552,13 @@ async def test_memory_retrieval_with_no_links(cortex, mock_psycopg2):
 @pytest.mark.asyncio
 async def test_get_memory_graph_with_custom_depth(cortex, mock_psycopg2):
     """Test memory graph retrieval with custom depth."""
-    mock_psycopg2['cursor'].fetchall.side_effect = [[], []]  # Empty nodes and edges
+    mock_psycopg2["cursor"].fetchall.side_effect = [[], []]  # Empty nodes and edges
 
     await cortex.get_memory_graph("test-node", depth=5)
 
     # Verify depth parameter was passed correctly
     # Check all execute calls to find the one with the depth parameter
-    execute_calls = mock_psycopg2['cursor'].execute.call_args_list
+    execute_calls = mock_psycopg2["cursor"].execute.call_args_list
     found_depth_call = False
     for call in execute_calls:
         if len(call[0]) > 1 and call[0][1] == ("test-node", 5):

--- a/tests/test_coverage_improvement.py
+++ b/tests/test_coverage_improvement.py
@@ -34,7 +34,7 @@ async def test_api_cortex_disabled_debug():
 
     config = EpistemicConfig(
         debug=True,
-        enable_cortex=True  # Enable cortex to trigger initialization attempt
+        enable_cortex=True,  # Enable cortex to trigger initialization attempt
     )
     api = EpistemicAPI(config)
 
@@ -52,7 +52,7 @@ async def test_api_consolidation_engine_paths():
 
     config = EpistemicConfig(
         debug=True,
-        enable_consolidation=True  # Enable to trigger initialization
+        enable_consolidation=True,  # Enable to trigger initialization
     )
     api = EpistemicAPI(config)
 
@@ -66,10 +66,7 @@ async def test_api_retrieval_engine_paths():
     from episemic.api import EpistemicAPI
     from episemic.config import EpistemicConfig
 
-    config = EpistemicConfig(
-        debug=True,
-        enable_retrieval=True
-    )
+    config = EpistemicConfig(debug=True, enable_retrieval=True)
     api = EpistemicAPI(config)
 
     result = await api.initialize()
@@ -106,7 +103,7 @@ async def test_api_fallback_scenarios():
         enable_cortex=False,
         enable_consolidation=False,
         enable_retrieval=False,
-        debug=True  # Enable debug to cover debug paths
+        debug=True,  # Enable debug to cover debug paths
     )
     api = EpistemicAPI(config)
 

--- a/tests/test_duckdb_comprehensive.py
+++ b/tests/test_duckdb_comprehensive.py
@@ -14,7 +14,7 @@ from episemic.models import Memory
 
 
 @pytest.mark.asyncio
-@patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer')
+@patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer")
 async def test_duckdb_initialization_and_health(mock_transformer):
     """Test DuckDB initialization and health check."""
     # Mock the sentence transformer
@@ -45,7 +45,7 @@ async def test_duckdb_initialization_and_health(mock_transformer):
 
 
 @pytest.mark.asyncio
-@patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer')
+@patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer")
 async def test_duckdb_memory_operations(mock_transformer):
     """Test comprehensive memory operations."""
     # Mock the sentence transformer
@@ -71,7 +71,7 @@ async def test_duckdb_memory_operations(mock_transformer):
             summary="This is a comprehensive test memory",
             source="test",
             tags=["test", "comprehensive"],
-            metadata={"importance": "high", "category": "testing"}
+            metadata={"importance": "high", "category": "testing"},
         )
 
         # Store memory
@@ -119,7 +119,7 @@ async def test_duckdb_memory_operations(mock_transformer):
 
 
 @pytest.mark.asyncio
-@patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer')
+@patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer")
 async def test_duckdb_vector_search_comprehensive(mock_transformer):
     """Test comprehensive vector search functionality."""
     # Mock the sentence transformer
@@ -138,7 +138,7 @@ async def test_duckdb_vector_search_comprehensive(mock_transformer):
             summary=f"Content for memory number {i}",
             source=f"source_{i % 2}",  # Alternate sources
             tags=[f"tag_{i}", "common"] if i % 2 == 0 else [f"tag_{i}"],
-            metadata={"index": i, "even": i % 2 == 0}
+            metadata={"index": i, "even": i % 2 == 0},
         )
         memories.append(memory)
         await hippocampus.store_memory(memory)
@@ -149,18 +149,14 @@ async def test_duckdb_vector_search_comprehensive(mock_transformer):
     assert len(results) == 3
 
     # Test search with tag filter
-    results = await hippocampus.vector_search(
-        embedding, top_k=10, filters={"tags": "common"}
-    )
+    results = await hippocampus.vector_search(embedding, top_k=10, filters={"tags": "common"})
     # Should find memories with "common" tag (even indices: 0, 2, 4)
     assert len(results) == 3
     for result in results:
         assert "common" in result["tags"]
 
     # Test search with source filter
-    results = await hippocampus.vector_search(
-        embedding, top_k=10, filters={"source": "source_0"}
-    )
+    results = await hippocampus.vector_search(embedding, top_k=10, filters={"source": "source_0"})
     # Should find memories with source_0 (even indices: 0, 2, 4)
     assert len(results) == 3
     for result in results:
@@ -172,7 +168,7 @@ async def test_duckdb_vector_search_comprehensive(mock_transformer):
 
 
 @pytest.mark.asyncio
-@patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer')
+@patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer")
 async def test_duckdb_error_handling(mock_transformer):
     """Test error handling in DuckDB operations."""
     # Mock the sentence transformer to raise an error
@@ -182,10 +178,7 @@ async def test_duckdb_error_handling(mock_transformer):
 
     # Test store memory with model error
     memory = Memory(
-        title="Error Test",
-        text="This should fail",
-        summary="This should fail",
-        source="test"
+        title="Error Test", text="This should fail", summary="This should fail", source="test"
     )
 
     # This should fall back gracefully and still work (without embeddings)
@@ -206,7 +199,7 @@ async def test_duckdb_error_handling(mock_transformer):
     assert result is True
 
     # Test error in vector search
-    with patch.object(hippocampus2, 'conn') as mock_conn:
+    with patch.object(hippocampus2, "conn") as mock_conn:
         mock_conn.execute.side_effect = Exception("Database error")
 
         embedding = await hippocampus2.get_embedding("test")
@@ -215,7 +208,7 @@ async def test_duckdb_error_handling(mock_transformer):
 
 
 @pytest.mark.asyncio
-@patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer')
+@patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer")
 async def test_duckdb_close_operation(mock_transformer):
     """Test DuckDB close operation."""
     # Mock the sentence transformer
@@ -230,7 +223,7 @@ async def test_duckdb_close_operation(mock_transformer):
     hippocampus.close()
 
     # After close, should not have conn attribute
-    assert not hasattr(hippocampus, 'conn') or hippocampus.conn is None
+    assert not hasattr(hippocampus, "conn") or hippocampus.conn is None
 
 
 def test_duckdb_config_integration():
@@ -241,10 +234,7 @@ def test_duckdb_config_integration():
     assert config.model_name == "all-MiniLM-L6-v2"
 
     # Test custom config
-    config = DuckDBConfig(
-        db_path="/tmp/test.db",
-        model_name="custom-model"
-    )
+    config = DuckDBConfig(db_path="/tmp/test.db", model_name="custom-model")
     assert config.db_path == "/tmp/test.db"
     assert config.model_name == "custom-model"
 
@@ -256,7 +246,7 @@ def test_duckdb_config_integration():
 
 
 @pytest.mark.asyncio
-@patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer')
+@patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer")
 async def test_duckdb_file_persistence(mock_transformer):
     """Test file persistence across sessions."""
     # Mock the sentence transformer
@@ -277,7 +267,7 @@ async def test_duckdb_file_persistence(mock_transformer):
             text="This memory should persist across sessions",
             summary="This memory should persist across sessions",
             source="persistence_test",
-            tags=["persistent"]
+            tags=["persistent"],
         )
 
         result = await hippocampus1.store_memory(memory)
@@ -307,7 +297,7 @@ async def test_duckdb_file_persistence(mock_transformer):
 
 
 @pytest.mark.asyncio
-@patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer')
+@patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer")
 async def test_duckdb_multiple_memories_search(mock_transformer):
     """Test search with multiple memories and various scenarios."""
     # Mock the sentence transformer with different embeddings
@@ -329,21 +319,19 @@ async def test_duckdb_multiple_memories_search(mock_transformer):
 
     # Store diverse memories
     memories_data = [
-        ("Python Programming", "Python is a versatile programming language", ["python", "programming"]),
+        (
+            "Python Programming",
+            "Python is a versatile programming language",
+            ["python", "programming"],
+        ),
         ("JavaScript Basics", "JavaScript runs in browsers and servers", ["javascript", "web"]),
         ("Database Design", "Database design is crucial for applications", ["database", "design"]),
         ("Machine Learning", "ML algorithms learn from data", ["ml", "ai"]),
-        ("Web Development", "Building web applications with modern tools", ["web", "development"])
+        ("Web Development", "Building web applications with modern tools", ["web", "development"]),
     ]
 
     for title, text, tags in memories_data:
-        memory = Memory(
-            title=title,
-            text=text,
-            summary=text,
-            source="knowledge_base",
-            tags=tags
-        )
+        memory = Memory(title=title, text=text, summary=text, source="knowledge_base", tags=tags)
         await hippocampus.store_memory(memory)
 
     # Test search for Python-related content

--- a/tests/test_duckdb_error_paths.py
+++ b/tests/test_duckdb_error_paths.py
@@ -11,7 +11,7 @@ from episemic.models import Memory
 
 
 @pytest.mark.asyncio
-@patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer')
+@patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer")
 async def test_duckdb_store_memory_encoding_error(mock_transformer):
     """Test store_memory with encoding error."""
     # Mock the sentence transformer to fail during encoding
@@ -26,7 +26,7 @@ async def test_duckdb_store_memory_encoding_error(mock_transformer):
         title="Error Test",
         text="This will cause an error",
         summary="This will cause an error",
-        source="error_test"
+        source="error_test",
     )
 
     # This should handle encoding errors gracefully
@@ -37,7 +37,7 @@ async def test_duckdb_store_memory_encoding_error(mock_transformer):
 @pytest.mark.asyncio
 async def test_duckdb_retrieve_memory_not_found():
     """Test retrieve_memory when memory doesn't exist."""
-    with patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer'):
+    with patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer"):
         hippocampus = DuckDBHippocampus(db_path=None)
         await hippocampus._ensure_initialized()
 
@@ -47,7 +47,7 @@ async def test_duckdb_retrieve_memory_not_found():
 
 
 @pytest.mark.asyncio
-@patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer')
+@patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer")
 async def test_duckdb_mark_quarantined_nonexistent(mock_transformer):
     """Test mark_quarantined on non-existent memory."""
     # Mock the sentence transformer
@@ -74,7 +74,7 @@ async def test_duckdb_verify_integrity_error_paths():
 
 
 @pytest.mark.asyncio
-@patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer')
+@patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer")
 async def test_duckdb_get_memory_count_normal_operation(mock_transformer):
     """Test get_memory_count normal operation."""
     # Mock the sentence transformer
@@ -95,7 +95,7 @@ async def test_duckdb_get_memory_count_normal_operation(mock_transformer):
 
 
 @pytest.mark.asyncio
-@patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer')
+@patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer")
 async def test_duckdb_health_check_error_paths(mock_transformer):
     """Test error paths in health_check."""
     # Test health check with model error
@@ -121,14 +121,14 @@ async def test_duckdb_health_check_error_paths(mock_transformer):
     except Exception:
         pass
 
-    if hasattr(hippocampus, 'model') and hippocampus.model:
+    if hasattr(hippocampus, "model") and hippocampus.model:
         health = hippocampus.health_check()
         # Should handle encoding errors gracefully
         assert isinstance(health, dict)
 
 
 @pytest.mark.asyncio
-@patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer')
+@patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer")
 async def test_duckdb_initialization_with_file_creation_error(mock_transformer):
     """Test initialization with file creation error."""
     # Mock the sentence transformer
@@ -138,6 +138,7 @@ async def test_duckdb_initialization_with_file_creation_error(mock_transformer):
 
     # Use tempfile to create a valid test scenario
     import tempfile
+
     with tempfile.TemporaryDirectory() as temp_dir:
         valid_path = f"{temp_dir}/test.db"
         hippocampus = DuckDBHippocampus(db_path=valid_path)
@@ -148,7 +149,7 @@ async def test_duckdb_initialization_with_file_creation_error(mock_transformer):
 
 
 @pytest.mark.asyncio
-@patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer')
+@patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer")
 async def test_duckdb_vector_search_edge_cases(mock_transformer):
     """Test vector search edge cases."""
     # Mock the sentence transformer
@@ -179,7 +180,7 @@ async def test_duckdb_vector_search_edge_cases(mock_transformer):
 
 
 @pytest.mark.asyncio
-@patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer')
+@patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer")
 async def test_duckdb_multiple_initialization_calls(mock_transformer):
     """Test calling _ensure_initialized multiple times."""
     # Mock the sentence transformer
@@ -203,7 +204,7 @@ async def test_duckdb_multiple_initialization_calls(mock_transformer):
 
 
 @pytest.mark.asyncio
-@patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer')
+@patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer")
 async def test_duckdb_close_without_connection(mock_transformer):
     """Test close operation when no connection exists."""
     hippocampus = DuckDBHippocampus(db_path=None)
@@ -241,7 +242,7 @@ def test_duckdb_config_directory_creation():
 
 
 @pytest.mark.asyncio
-@patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer')
+@patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer")
 async def test_duckdb_with_different_model_names(mock_transformer):
     """Test DuckDB with different model configurations."""
     # Test with custom model name
@@ -249,10 +250,7 @@ async def test_duckdb_with_different_model_names(mock_transformer):
     mock_model.encode.return_value.tolist.return_value = [0.8] * 512  # Different size
     mock_transformer.return_value = mock_model
 
-    hippocampus = DuckDBHippocampus(
-        db_path=None,
-        model_name="custom-model-name"
-    )
+    hippocampus = DuckDBHippocampus(db_path=None, model_name="custom-model-name")
 
     await hippocampus._ensure_initialized()
 

--- a/tests/test_duckdb_fallback.py
+++ b/tests/test_duckdb_fallback.py
@@ -15,7 +15,7 @@ from episemic.simple import Episemic
 
 
 @pytest.mark.asyncio
-@patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer')
+@patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer")
 async def test_duckdb_hippocampus_basic_operations(mock_transformer):
     """Test basic DuckDB hippocampus operations."""
     # Mock the sentence transformer
@@ -39,7 +39,7 @@ async def test_duckdb_hippocampus_basic_operations(mock_transformer):
             summary="This is a test memory for DuckDB storage",
             source="test",
             tags=["test", "duckdb"],
-            metadata={"test": True}
+            metadata={"test": True},
         )
 
         # Test storing memory
@@ -85,7 +85,7 @@ async def test_duckdb_hippocampus_basic_operations(mock_transformer):
 
 
 @pytest.mark.asyncio
-@patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer')
+@patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer")
 async def test_simple_api_with_duckdb_fallback(mock_transformer):
     """Test simple API automatically using DuckDB fallback."""
     # Mock the sentence transformer
@@ -114,7 +114,7 @@ async def test_simple_api_with_duckdb_fallback(mock_transformer):
             memory = await episemic.remember(
                 "DuckDB makes local storage easy",
                 title="DuckDB Benefits",
-                tags=["database", "local"]
+                tags=["database", "local"],
             )
             assert memory is not None
             assert "DuckDB" in memory.text
@@ -148,7 +148,7 @@ async def test_simple_api_with_duckdb_fallback(mock_transformer):
 
 
 @pytest.mark.asyncio
-@patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer')
+@patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer")
 async def test_duckdb_with_in_memory_db(mock_transformer):
     """Test DuckDB with in-memory database."""
     # Mock the sentence transformer
@@ -164,7 +164,7 @@ async def test_duckdb_with_in_memory_db(mock_transformer):
         text="This memory is stored in-memory using DuckDB",
         summary="This memory is stored in-memory using DuckDB",
         source="test",
-        tags=["memory", "in-memory"]
+        tags=["memory", "in-memory"],
     )
 
     # Test basic operations
@@ -180,7 +180,7 @@ async def test_duckdb_with_in_memory_db(mock_transformer):
 
 
 @pytest.mark.asyncio
-@patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer')
+@patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer")
 async def test_duckdb_vector_search_with_filters(mock_transformer):
     """Test DuckDB vector search with various filters."""
     # Mock the sentence transformer
@@ -203,22 +203,22 @@ async def test_duckdb_vector_search_with_filters(mock_transformer):
                 text="Python is a versatile programming language",
                 summary="Python is a versatile programming language",
                 source="book",
-                tags=["python", "programming"]
+                tags=["python", "programming"],
             ),
             Memory(
                 title="Database Design",
                 text="Database design is crucial for application performance",
                 summary="Database design is crucial for application performance",
                 source="article",
-                tags=["database", "design"]
+                tags=["database", "design"],
             ),
             Memory(
                 title="Python Database",
                 text="Python has excellent database connectivity options",
                 summary="Python has excellent database connectivity options",
                 source="tutorial",
-                tags=["python", "database"]
-            )
+                tags=["python", "database"],
+            ),
         ]
 
         # Store all memories
@@ -227,11 +227,7 @@ async def test_duckdb_vector_search_with_filters(mock_transformer):
 
         # Test search with tag filter
         embedding = await hippocampus.get_embedding("python programming")
-        results = await hippocampus.vector_search(
-            embedding,
-            top_k=5,
-            filters={"tags": "python"}
-        )
+        results = await hippocampus.vector_search(embedding, top_k=5, filters={"tags": "python"})
 
         # Should find memories tagged with "python"
         assert len(results) >= 2
@@ -239,11 +235,7 @@ async def test_duckdb_vector_search_with_filters(mock_transformer):
             assert "python" in result["tags"]
 
         # Test search with source filter
-        results = await hippocampus.vector_search(
-            embedding,
-            top_k=5,
-            filters={"source": "book"}
-        )
+        results = await hippocampus.vector_search(embedding, top_k=5, filters={"source": "book"})
 
         # Should find only book source
         assert len(results) >= 1

--- a/tests/test_final_coverage_push.py
+++ b/tests/test_final_coverage_push.py
@@ -17,7 +17,7 @@ async def test_api_qdrant_preference_paths():
     # Test with Qdrant preference enabled but Qdrant not available
     config = EpistemicConfig(
         prefer_qdrant=True,  # This should trigger Qdrant path but fall back to DuckDB
-        debug=True
+        debug=True,
     )
     api = EpistemicAPI(config)
 
@@ -34,7 +34,7 @@ async def test_api_cortex_initialization_paths():
     # Test with cortex enabled to trigger initialization attempt
     config = EpistemicConfig(
         enable_cortex=True,  # This should trigger cortex initialization (lines 116-129)
-        debug=True
+        debug=True,
     )
     api = EpistemicAPI(config)
 
@@ -49,7 +49,7 @@ async def test_api_consolidation_initialization():
 
     config = EpistemicConfig(
         enable_consolidation=True,  # Trigger consolidation initialization (lines 139-151)
-        debug=True
+        debug=True,
     )
     api = EpistemicAPI(config)
 
@@ -64,7 +64,7 @@ async def test_api_retrieval_initialization():
 
     config = EpistemicConfig(
         enable_retrieval=True,  # Trigger retrieval initialization (lines 153-167)
-        debug=True
+        debug=True,
     )
     api = EpistemicAPI(config)
 
@@ -95,11 +95,7 @@ async def test_api_health_check_variations():
     """Test health check with different configurations."""
     from episemic.api import EpistemicAPI
 
-    config = EpistemicConfig(
-        enable_cortex=True,
-        enable_consolidation=True,
-        enable_retrieval=True
-    )
+    config = EpistemicConfig(enable_cortex=True, enable_consolidation=True, enable_retrieval=True)
     api = EpistemicAPI(config)
     await api.initialize()
 
@@ -109,7 +105,7 @@ async def test_api_health_check_variations():
 
 
 @pytest.mark.asyncio
-@patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer')
+@patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer")
 async def test_duckdb_error_fallback_paths(mock_transformer):
     """Test DuckDB error fallback paths."""
     from episemic.hippocampus.duckdb_hippocampus import DuckDBHippocampus
@@ -123,7 +119,7 @@ async def test_duckdb_error_fallback_paths(mock_transformer):
         title="Fallback Test",
         text="This should trigger fallback",
         summary="Fallback summary",
-        source="test"
+        source="test",
     )
 
     # This should trigger the embedding error fallback
@@ -132,7 +128,7 @@ async def test_duckdb_error_fallback_paths(mock_transformer):
 
 
 @pytest.mark.asyncio
-@patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer')
+@patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer")
 async def test_duckdb_text_search_fallback(mock_transformer):
     """Test DuckDB text search fallback paths."""
     from episemic.hippocampus.duckdb_hippocampus import DuckDBHippocampus
@@ -151,7 +147,7 @@ async def test_duckdb_text_search_fallback(mock_transformer):
 
 
 @pytest.mark.asyncio
-@patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer')
+@patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer")
 async def test_duckdb_quarantine_and_integrity(mock_transformer):
     """Test DuckDB quarantine and integrity methods."""
     from episemic.hippocampus.duckdb_hippocampus import DuckDBHippocampus
@@ -166,10 +162,7 @@ async def test_duckdb_quarantine_and_integrity(mock_transformer):
 
     # Store a memory first
     memory = Memory(
-        title="Quarantine Test",
-        text="Test content",
-        summary="Test summary",
-        source="test"
+        title="Quarantine Test", text="Test content", summary="Test summary", source="test"
     )
     await hippocampus.store_memory(memory)
 
@@ -274,12 +267,10 @@ async def test_config_from_environment():
     from episemic.config import EpistemicConfig
 
     # Test from_env method
-    with patch.dict(os.environ, {
-        'EPISEMIC_DEBUG': 'true',
-        'QDRANT_HOST': 'test-host',
-        'POSTGRES_DB': 'test-db'
-    }):
+    with patch.dict(
+        os.environ, {"EPISEMIC_DEBUG": "true", "QDRANT_HOST": "test-host", "POSTGRES_DB": "test-db"}
+    ):
         config = EpistemicConfig.from_env()
         assert config.debug is True
-        assert config.qdrant.host == 'test-host'
-        assert config.postgresql.database == 'test-db'
+        assert config.qdrant.host == "test-host"
+        assert config.postgresql.database == "test-db"

--- a/tests/test_import_error_simulation.py
+++ b/tests/test_import_error_simulation.py
@@ -48,12 +48,12 @@ async def test_force_qdrant_preference_unavailable():
     # Even if QDRANT_AVAILABLE is True, we can test the preference logic
     config = EpistemicConfig(
         prefer_qdrant=True,  # Force Qdrant preference
-        debug=True
+        debug=True,
     )
     api = EpistemicAPI(config)
 
     # Mock the availability check
-    with patch.object(api, '_should_use_duckdb', return_value=False):
+    with patch.object(api, "_should_use_duckdb", return_value=False):
         # This should attempt Qdrant path but may fall back
         result = await api.initialize()
         assert isinstance(result, bool)
@@ -63,8 +63,10 @@ def test_consolidation_imports():
     """Test that consolidation imports work correctly."""
     # Import consolidation module to test import paths
     import episemic.consolidation as cons_module
+
     assert cons_module is not None
 
     # Test that ConsolidationEngine is available
     from episemic.consolidation import ConsolidationEngine
+
     assert ConsolidationEngine is not None

--- a/tests/test_library_api.py
+++ b/tests/test_library_api.py
@@ -17,10 +17,7 @@ def test_config_creation():
     assert config.enable_hippocampus is True
 
     # Custom config
-    config = EpistemicConfig(
-        qdrant={"host": "custom-host", "port": 9999},
-        debug=True
-    )
+    config = EpistemicConfig(qdrant={"host": "custom-host", "port": 9999}, debug=True)
     assert config.qdrant.host == "custom-host"
     assert config.qdrant.port == 9999
     assert config.debug is True
@@ -28,11 +25,7 @@ def test_config_creation():
 
 def test_config_from_dict():
     """Test creating config from dictionary."""
-    config_dict = {
-        "qdrant": {"host": "test-host"},
-        "debug": True,
-        "enable_cortex": False
-    }
+    config_dict = {"qdrant": {"host": "test-host"}, "debug": True, "enable_cortex": False}
 
     config = EpistemicConfig.from_dict(config_dict)
     assert config.qdrant.host == "test-host"
@@ -53,10 +46,7 @@ def test_config_to_dict():
 
 def test_create_config_helper():
     """Test the create_config helper function."""
-    config = create_config(
-        enable_hippocampus=False,
-        debug=True
-    )
+    config = create_config(enable_hippocampus=False, debug=True)
 
     assert config.enable_hippocampus is False
     assert config.debug is True
@@ -91,7 +81,7 @@ async def test_api_initialization_with_disabled_services():
         enable_hippocampus=False,
         enable_cortex=False,
         enable_consolidation=False,
-        enable_retrieval=False
+        enable_retrieval=False,
     )
 
     api = EpistemicAPI(config)
@@ -115,7 +105,7 @@ async def test_api_context_manager():
         enable_hippocampus=True,  # Keep hippocampus enabled for minimum functionality
         enable_cortex=False,
         enable_consolidation=False,
-        enable_retrieval=False
+        enable_retrieval=False,
     )
 
     async with EpistemicAPI(config) as api:
@@ -128,10 +118,10 @@ def test_config_environment_structure():
     config = EpistemicConfig.from_env()
 
     # Should have all expected sections
-    assert hasattr(config, 'qdrant')
-    assert hasattr(config, 'postgresql')
-    assert hasattr(config, 'redis')
-    assert hasattr(config, 'consolidation')
+    assert hasattr(config, "qdrant")
+    assert hasattr(config, "postgresql")
+    assert hasattr(config, "redis")
+    assert hasattr(config, "consolidation")
 
     # Should have proper types
     assert isinstance(config.qdrant.host, str)

--- a/tests/test_missing_coverage.py
+++ b/tests/test_missing_coverage.py
@@ -11,7 +11,7 @@ from episemic.models import Memory
 
 
 @pytest.mark.asyncio
-@patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer')
+@patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer")
 async def test_duckdb_hippocampus_embedding_error_fallback(mock_transformer):
     """Test DuckDB hippocampus fallback when embedding generation fails."""
     from episemic.hippocampus.duckdb_hippocampus import DuckDBHippocampus
@@ -21,12 +21,7 @@ async def test_duckdb_hippocampus_embedding_error_fallback(mock_transformer):
 
     hippocampus = DuckDBHippocampus(db_path=None)
 
-    memory = Memory(
-        title="Test Memory",
-        text="Test content",
-        summary="Test summary",
-        source="test"
-    )
+    memory = Memory(title="Test Memory", text="Test content", summary="Test summary", source="test")
 
     # This should trigger the embedding error fallback (line 92)
     result = await hippocampus.store_memory(memory)
@@ -34,7 +29,7 @@ async def test_duckdb_hippocampus_embedding_error_fallback(mock_transformer):
 
 
 @pytest.mark.asyncio
-@patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer')
+@patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer")
 async def test_duckdb_various_error_paths(mock_transformer):
     """Test various error paths in DuckDB hippocampus."""
     from episemic.hippocampus.duckdb_hippocampus import DuckDBHippocampus
@@ -95,6 +90,7 @@ async def test_retrieval_engine_error_paths():
     mock_hippocampus.vector_search.return_value = []
 
     from episemic.models import SearchQuery
+
     query = SearchQuery(query="test", top_k=5)
 
     results = await engine.search(query)
@@ -118,9 +114,7 @@ async def test_simple_api_error_paths():
 
     # Test remember with metadata that triggers JSON serialization
     memory = await episemic.remember(
-        "Test content",
-        title="Test",
-        metadata={"complex": {"nested": "data"}}
+        "Test content", title="Test", metadata={"complex": {"nested": "data"}}
     )
     assert memory is not None
 
@@ -145,10 +139,7 @@ async def test_config_edge_cases():
 
     # Test config creation with various parameters
     config = EpistemicConfig(
-        debug=True,
-        enable_cortex=True,
-        enable_consolidation=True,
-        enable_retrieval=True
+        debug=True, enable_cortex=True, enable_consolidation=True, enable_retrieval=True
     )
 
     assert config.debug is True
@@ -156,7 +147,7 @@ async def test_config_edge_cases():
 
 
 @pytest.mark.asyncio
-@patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer')
+@patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer")
 async def test_duckdb_file_operations(mock_transformer):
     """Test DuckDB file-based operations."""
     from episemic.hippocampus.duckdb_hippocampus import DuckDBHippocampus
@@ -176,10 +167,7 @@ async def test_duckdb_file_operations(mock_transformer):
         await hippocampus._ensure_initialized()
 
         memory = Memory(
-            title="File Test",
-            text="File content",
-            summary="File summary",
-            source="test"
+            title="File Test", text="File content", summary="File summary", source="test"
         )
 
         result = await hippocampus.store_memory(memory)
@@ -207,7 +195,7 @@ async def test_models_edge_cases():
         summary="Complete summary",
         source="test",
         tags=["tag1", "tag2"],
-        metadata={"key": "value"}
+        metadata={"key": "value"},
     )
 
     # Test memory methods
@@ -224,10 +212,6 @@ async def test_models_edge_cases():
     assert memory.access_count == original_count + 1
 
     # Test memory link
-    link = MemoryLink(
-        target_id="target-123",
-        type=LinkType.CITES,
-        weight=0.8
-    )
+    link = MemoryLink(target_id="target-123", type=LinkType.CITES, weight=0.8)
     assert link.target_id == "target-123"
     assert link.type == LinkType.CITES

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -11,7 +11,7 @@ def test_memory_creation():
         text="This is a test memory",
         summary="Test summary",
         source="test",
-        tags=["test", "memory"]
+        tags=["test", "memory"],
     )
 
     assert memory.title == "Test Memory"
@@ -24,10 +24,7 @@ def test_memory_creation():
 
 def test_memory_hash_computation():
     memory = Memory(
-        title="Test Memory",
-        text="This is a test memory",
-        summary="Test summary",
-        source="test"
+        title="Test Memory", text="This is a test memory", summary="Test summary", source="test"
     )
 
     expected_hash = memory.compute_hash()
@@ -37,10 +34,7 @@ def test_memory_hash_computation():
 
 def test_memory_integrity_verification():
     memory = Memory(
-        title="Test Memory",
-        text="This is a test memory",
-        summary="Test summary",
-        source="test"
+        title="Test Memory", text="This is a test memory", summary="Test summary", source="test"
     )
 
     assert memory.verify_integrity() is True
@@ -52,10 +46,7 @@ def test_memory_integrity_verification():
 
 def test_memory_access_increment():
     memory = Memory(
-        title="Test Memory",
-        text="This is a test memory",
-        summary="Test summary",
-        source="test"
+        title="Test Memory", text="This is a test memory", summary="Test summary", source="test"
     )
 
     initial_count = memory.access_count
@@ -69,11 +60,7 @@ def test_memory_access_increment():
 
 
 def test_memory_link():
-    link = MemoryLink(
-        target_id="test-target-id",
-        type=LinkType.CITES,
-        weight=0.8
-    )
+    link = MemoryLink(target_id="test-target-id", type=LinkType.CITES, weight=0.8)
 
     assert link.target_id == "test-target-id"
     assert link.type == LinkType.CITES

--- a/tests/test_remaining_lines.py
+++ b/tests/test_remaining_lines.py
@@ -10,7 +10,7 @@ from episemic.models import Memory
 
 
 @pytest.mark.asyncio
-@patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer')
+@patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer")
 async def test_duckdb_specific_error_lines(mock_transformer):
     """Test specific error lines in DuckDB hippocampus."""
     from episemic.hippocampus.duckdb_hippocampus import DuckDBHippocampus
@@ -28,7 +28,7 @@ async def test_duckdb_specific_error_lines(mock_transformer):
         title="Test Memory",
         text="Test content for specific lines",
         summary="Test summary",
-        source="test"
+        source="test",
     )
     result = await hippocampus.store_memory(memory)
     assert result is True
@@ -36,9 +36,9 @@ async def test_duckdb_specific_error_lines(mock_transformer):
     # Test specific methods to hit missing lines
 
     # Test vector search with filters (line around 283-284)
-    with patch.object(hippocampus, 'conn') as mock_con:
+    with patch.object(hippocampus, "conn") as mock_con:
         mock_con.execute.return_value.fetchall.return_value = []
-        results = await hippocampus.vector_search([0.1] * 384, top_k=5, filters={'source': 'test'})
+        results = await hippocampus.vector_search([0.1] * 384, top_k=5, filters={"source": "test"})
         assert results == []
 
     # Test _fallback_text_search specific paths (lines around 286-287)
@@ -91,11 +91,7 @@ async def test_retrieval_engine_specific_paths():
     from episemic.models import SearchQuery
 
     # Test with embedding
-    query_with_embedding = SearchQuery(
-        query="test",
-        top_k=5,
-        embedding=[0.1] * 384
-    )
+    query_with_embedding = SearchQuery(query="test", top_k=5, embedding=[0.1] * 384)
     results = await engine.search(query_with_embedding)
     assert isinstance(results, list)
 
@@ -140,7 +136,7 @@ async def test_api_specific_error_conditions():
 
 
 @pytest.mark.asyncio
-@patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer')
+@patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer")
 async def test_duckdb_initialization_edge_cases(mock_transformer):
     """Test DuckDB initialization edge cases."""
     from episemic.hippocampus.duckdb_hippocampus import DuckDBHippocampus
@@ -158,7 +154,7 @@ async def test_duckdb_initialization_edge_cases(mock_transformer):
         title="Fallback Test",
         text="Should work without embeddings",
         summary="Fallback summary",
-        source="test"
+        source="test",
     )
     result = await hippocampus.store_memory(memory)
     assert result is True  # Should work in fallback mode
@@ -175,17 +171,14 @@ def test_config_edge_cases():
         enable_hippocampus=True,
         enable_cortex=False,
         enable_consolidation=False,
-        enable_retrieval=True
+        enable_retrieval=True,
     )
 
     assert config.debug is False
     assert config.log_level == "DEBUG"
 
     # Test from_dict method
-    config_dict = {
-        "debug": True,
-        "enable_cortex": True
-    }
+    config_dict = {"debug": True, "enable_cortex": True}
     config_from_dict = EpistemicConfig.from_dict(config_dict)
     assert config_from_dict.debug is True
     assert config_from_dict.enable_cortex is True
@@ -224,12 +217,7 @@ async def test_hippocampus_error_conditions():
     try:
         hippocampus = Hippocampus()
         # If it succeeds, test some operations
-        memory = Memory(
-            title="Test",
-            text="Test content",
-            summary="Test summary",
-            source="test"
-        )
+        memory = Memory(title="Test", text="Test content", summary="Test summary", source="test")
         await hippocampus.store_memory(memory)
     except Exception:
         # Expected - Qdrant/Redis not available in test environment
@@ -242,40 +230,23 @@ def test_model_edge_cases():
     from episemic.models import Memory, MemoryLink, LinkType, SearchQuery, SearchResult
 
     # Test memory with minimal data
-    memory = Memory(
-        title="",
-        text="",
-        summary="",
-        source=""
-    )
+    memory = Memory(title="", text="", summary="", source="")
     assert memory.title == ""
     assert memory.text == ""
 
     # Test memory link with different types
-    link = MemoryLink(
-        target_id="test",
-        type=LinkType.DERIVED_FROM,
-        weight=0.0
-    )
+    link = MemoryLink(target_id="test", type=LinkType.DERIVED_FROM, weight=0.0)
     assert link.type == LinkType.DERIVED_FROM
     assert link.weight == 0.0
 
     # Test search query edge cases
-    query = SearchQuery(
-        query="",
-        top_k=0,
-        filters={},
-        include_quarantined=True
-    )
+    query = SearchQuery(query="", top_k=0, filters={}, include_quarantined=True)
     assert query.top_k == 0
     assert query.include_quarantined is True
 
     # Test search result
     result = SearchResult(
-        memory=memory,
-        score=1.0,
-        provenance={"test": "data"},
-        retrieval_path=["hippocampus"]
+        memory=memory, score=1.0, provenance={"test": "data"}, retrieval_path=["hippocampus"]
     )
     assert result.score == 1.0
     assert result.provenance == {"test": "data"}

--- a/tests/test_retrieval_engine.py
+++ b/tests/test_retrieval_engine.py
@@ -46,7 +46,7 @@ def sample_memory():
         summary="Test memory summary",
         source="test",
         tags=["test", "memory"],
-        metadata={"category": "test"}
+        metadata={"category": "test"},
     )
 
 
@@ -57,7 +57,7 @@ def sample_search_query():
         query="test query",
         top_k=5,
         filters={"tags": ["test"], "source": "test"},
-        embedding=[0.1] * 768
+        embedding=[0.1] * 768,
     )
 
 
@@ -70,15 +70,12 @@ async def test_retrieval_engine_initialization(mock_hippocampus, mock_cortex):
 
 
 @pytest.mark.asyncio
-async def test_search_with_vector_similarity(retrieval_engine, mock_hippocampus, sample_memory, sample_search_query):
+async def test_search_with_vector_similarity(
+    retrieval_engine, mock_hippocampus, sample_memory, sample_search_query
+):
     """Test search with vector similarity path."""
     # Mock hippocampus vector search results
-    mock_hippocampus.vector_search.return_value = [
-        {
-            "memory": sample_memory,
-            "score": 0.9
-        }
-    ]
+    mock_hippocampus.vector_search.return_value = [{"memory": sample_memory, "score": 0.9}]
 
     results = await retrieval_engine.search(sample_search_query)
 
@@ -86,7 +83,7 @@ async def test_search_with_vector_similarity(retrieval_engine, mock_hippocampus,
     mock_hippocampus.vector_search.assert_called_once_with(
         query_vector=sample_search_query.embedding,
         top_k=sample_search_query.top_k,
-        filters={"tags": ["test"], "source": "test"}
+        filters={"tags": ["test"], "source": "test"},
     )
 
     # Verify results
@@ -97,7 +94,9 @@ async def test_search_with_vector_similarity(retrieval_engine, mock_hippocampus,
 
 
 @pytest.mark.asyncio
-async def test_search_with_tag_based_search(retrieval_engine, mock_cortex, sample_memory, sample_search_query):
+async def test_search_with_tag_based_search(
+    retrieval_engine, mock_cortex, sample_memory, sample_search_query
+):
     """Test search with tag-based path."""
     # Mock cortex tag search results
     mock_cortex.search_by_tags.return_value = [sample_memory]
@@ -105,10 +104,7 @@ async def test_search_with_tag_based_search(retrieval_engine, mock_cortex, sampl
     results = await retrieval_engine.search(sample_search_query)
 
     # Verify cortex was called
-    mock_cortex.search_by_tags.assert_called_once_with(
-        tags=["test"],
-        limit=5
-    )
+    mock_cortex.search_by_tags.assert_called_once_with(tags=["test"], limit=5)
 
     # Verify results
     assert len(results) == 1
@@ -120,18 +116,11 @@ async def test_search_with_tag_based_search(retrieval_engine, mock_cortex, sampl
 async def test_search_with_context_memory(retrieval_engine, mock_cortex, sample_memory):
     """Test search with context memory ID."""
     # Create query with context memory ID
-    query = SearchQuery(
-        query="test",
-        top_k=3,
-        filters={"context_memory_id": "context-id"}
-    )
+    query = SearchQuery(query="test", top_k=3, filters={"context_memory_id": "context-id"})
 
     # Mock graph data
     mock_cortex.get_memory_graph.return_value = {
-        "nodes": [
-            {"id": "context-id"},
-            {"id": "related-id"}
-        ]
+        "nodes": [{"id": "context-id"}, {"id": "related-id"}]
     }
     mock_cortex.retrieve_memory.return_value = sample_memory
 
@@ -147,7 +136,7 @@ async def test_search_error_handling(retrieval_engine, mock_hippocampus, sample_
     # Make hippocampus raise an exception
     mock_hippocampus.vector_search.side_effect = Exception("Vector search failed")
 
-    with patch('builtins.print') as mock_print:
+    with patch("builtins.print") as mock_print:
         results = await retrieval_engine.search(sample_search_query)
 
     # Should return empty list on error
@@ -156,7 +145,9 @@ async def test_search_error_handling(retrieval_engine, mock_hippocampus, sample_
 
 
 @pytest.mark.asyncio
-async def test_retrieve_by_id_from_hippocampus(retrieval_engine, mock_hippocampus, mock_cortex, sample_memory):
+async def test_retrieve_by_id_from_hippocampus(
+    retrieval_engine, mock_hippocampus, mock_cortex, sample_memory
+):
     """Test retrieving memory by ID from hippocampus."""
     mock_hippocampus.retrieve_memory.return_value = sample_memory
 
@@ -169,7 +160,9 @@ async def test_retrieve_by_id_from_hippocampus(retrieval_engine, mock_hippocampu
 
 
 @pytest.mark.asyncio
-async def test_retrieve_by_id_fallback_to_cortex(retrieval_engine, mock_hippocampus, mock_cortex, sample_memory):
+async def test_retrieve_by_id_fallback_to_cortex(
+    retrieval_engine, mock_hippocampus, mock_cortex, sample_memory
+):
     """Test retrieving memory by ID with fallback to cortex."""
     mock_hippocampus.retrieve_memory.return_value = None
     mock_cortex.retrieve_memory.return_value = sample_memory
@@ -205,7 +198,7 @@ async def test_get_related_memories_by_tags(retrieval_engine, mock_cortex, sampl
         text="Base content",
         summary="Base summary",
         source="test",
-        tags=["python", "programming"]
+        tags=["python", "programming"],
     )
 
     # Create related memory
@@ -215,11 +208,11 @@ async def test_get_related_memories_by_tags(retrieval_engine, mock_cortex, sampl
         text="Related content",
         summary="Related summary",
         source="test",
-        tags=["python", "coding"]
+        tags=["python", "coding"],
     )
 
     # Mock the retrieval engine's retrieve_by_id method
-    with patch.object(retrieval_engine, 'retrieve_by_id', return_value=base_memory):
+    with patch.object(retrieval_engine, "retrieve_by_id", return_value=base_memory):
         mock_cortex.search_by_tags.return_value = [related_memory]
 
         results = await retrieval_engine.get_related_memories("base-id", max_related=3)
@@ -227,7 +220,7 @@ async def test_get_related_memories_by_tags(retrieval_engine, mock_cortex, sampl
     # Verify tag search was called
     mock_cortex.search_by_tags.assert_called_with(
         tags=["python", "programming"],
-        limit=6  # max_related * 2
+        limit=6,  # max_related * 2
     )
 
     assert len(results) == 1
@@ -244,19 +237,16 @@ async def test_get_related_memories_by_graph(retrieval_engine, mock_cortex, samp
         text="Base content",
         summary="Base summary",
         source="test",
-        tags=["test"]
+        tags=["test"],
     )
 
     # Mock graph data with connected nodes
     mock_cortex.get_memory_graph.return_value = {
-        "nodes": [
-            {"id": "base-id"},
-            {"id": "connected-id"}
-        ]
+        "nodes": [{"id": "base-id"}, {"id": "connected-id"}]
     }
     mock_cortex.retrieve_memory.return_value = sample_memory
 
-    with patch.object(retrieval_engine, 'retrieve_by_id', return_value=base_memory):
+    with patch.object(retrieval_engine, "retrieve_by_id", return_value=base_memory):
         results = await retrieval_engine.get_related_memories("base-id")
 
     # Verify graph traversal was called
@@ -267,7 +257,7 @@ async def test_get_related_memories_by_graph(retrieval_engine, mock_cortex, samp
 @pytest.mark.asyncio
 async def test_get_related_memories_no_base_memory(retrieval_engine):
     """Test getting related memories when base memory doesn't exist."""
-    with patch.object(retrieval_engine, 'retrieve_by_id', return_value=None):
+    with patch.object(retrieval_engine, "retrieve_by_id", return_value=None):
         results = await retrieval_engine.get_related_memories("nonexistent-id")
 
     assert results == []
@@ -276,8 +266,10 @@ async def test_get_related_memories_no_base_memory(retrieval_engine):
 @pytest.mark.asyncio
 async def test_get_related_memories_error_handling(retrieval_engine, sample_memory):
     """Test error handling in get_related_memories."""
-    with patch.object(retrieval_engine, 'retrieve_by_id', side_effect=Exception("Retrieval failed")):
-        with patch('builtins.print') as mock_print:
+    with patch.object(
+        retrieval_engine, "retrieve_by_id", side_effect=Exception("Retrieval failed")
+    ):
+        with patch("builtins.print") as mock_print:
             results = await retrieval_engine.get_related_memories("test-id")
 
     assert results == []
@@ -289,10 +281,7 @@ async def test_search_by_context(retrieval_engine, mock_cortex, sample_memory):
     """Test _search_by_context method."""
     # Mock graph data
     mock_cortex.get_memory_graph.return_value = {
-        "nodes": [
-            {"id": "context-id"},
-            {"id": "related-id"}
-        ]
+        "nodes": [{"id": "context-id"}, {"id": "related-id"}]
     }
     mock_cortex.retrieve_memory.return_value = sample_memory
 
@@ -312,7 +301,7 @@ async def test_search_by_context_error_handling(retrieval_engine, mock_cortex):
     """Test error handling in _search_by_context."""
     mock_cortex.get_memory_graph.side_effect = Exception("Graph error")
 
-    with patch('builtins.print') as mock_print:
+    with patch("builtins.print") as mock_print:
         results = await retrieval_engine._search_by_context("context-id", top_k=5)
 
     assert results == []
@@ -344,17 +333,9 @@ def test_build_qdrant_filters(retrieval_engine):
     assert result == {"retention_policy": "archival"}
 
     # Test with multiple filters
-    filters = {
-        "tags": ["test"],
-        "source": "api",
-        "retention_policy": "default"
-    }
+    filters = {"tags": ["test"], "source": "api", "retention_policy": "default"}
     result = retrieval_engine._build_qdrant_filters(filters)
-    expected = {
-        "tags": {"any": ["test"]},
-        "source": "api",
-        "retention_policy": "default"
-    }
+    expected = {"tags": {"any": ["test"]}, "source": "api", "retention_policy": "default"}
     assert result == expected
 
 
@@ -372,7 +353,9 @@ def test_calculate_tag_relevance_score(retrieval_engine, sample_memory):
     assert score == 0.25
 
     # Test with complete overlap
-    score = retrieval_engine._calculate_tag_relevance_score(sample_memory, ["python", "programming", "tutorial"])
+    score = retrieval_engine._calculate_tag_relevance_score(
+        sample_memory, ["python", "programming", "tutorial"]
+    )
     assert score == 1.0
 
     # Test with empty tags
@@ -388,23 +371,18 @@ def test_calculate_tag_overlap_score(retrieval_engine):
     """Test _calculate_tag_overlap_score method."""
     # Test with overlap
     score = retrieval_engine._calculate_tag_overlap_score(
-        ["python", "programming"],
-        ["python", "tutorial"]
+        ["python", "programming"], ["python", "tutorial"]
     )
     # Overlap: 1, Union: 3, Score: 1/3
-    assert score == 1/3
+    assert score == 1 / 3
 
     # Test with no overlap
-    score = retrieval_engine._calculate_tag_overlap_score(
-        ["python"],
-        ["javascript"]
-    )
+    score = retrieval_engine._calculate_tag_overlap_score(["python"], ["javascript"])
     assert score == 0.0
 
     # Test with identical tags
     score = retrieval_engine._calculate_tag_overlap_score(
-        ["python", "programming"],
-        ["python", "programming"]
+        ["python", "programming"], ["python", "programming"]
     )
     assert score == 1.0
 
@@ -420,16 +398,13 @@ def test_deduplicate_results(retrieval_engine, sample_memory):
     """Test _deduplicate_results method."""
     # Create duplicate results
     result1 = SearchResult(
-        memory=sample_memory,
-        score=0.9,
-        provenance={"context": "context1"},
-        retrieval_path=[]
+        memory=sample_memory, score=0.9, provenance={"context": "context1"}, retrieval_path=[]
     )
     result2 = SearchResult(
         memory=sample_memory,  # Same memory
         score=0.8,
         provenance={"context": "context2"},
-        retrieval_path=[]
+        retrieval_path=[],
     )
 
     # Create different memory
@@ -438,13 +413,10 @@ def test_deduplicate_results(retrieval_engine, sample_memory):
         title="Other Memory",
         text="Other content",
         summary="Other summary",
-        source="test"
+        source="test",
     )
     result3 = SearchResult(
-        memory=other_memory,
-        score=0.7,
-        provenance={"context": "context3"},
-        retrieval_path=[]
+        memory=other_memory, score=0.7, provenance={"context": "context3"}, retrieval_path=[]
     )
 
     results = [result1, result2, result3]
@@ -465,7 +437,7 @@ def test_rank_results(retrieval_engine, sample_search_query):
         text="Content 1",
         summary="Summary 1",
         source="test",
-        access_count=3
+        access_count=3,
     )
     memory2 = Memory(
         id="memory2",
@@ -473,7 +445,7 @@ def test_rank_results(retrieval_engine, sample_search_query):
         text="Content 2",
         summary="Summary 2",
         source="test",
-        access_count=10  # High access count
+        access_count=10,  # High access count
     )
 
     result1 = SearchResult(memory=memory1, score=0.8, provenance={}, retrieval_path=[])
@@ -489,7 +461,9 @@ def test_rank_results(retrieval_engine, sample_search_query):
     assert len(ranked) == 2
     # The boost should make memory2's score higher: 0.7 * 1.1 = 0.77
     boosted_score = 0.7 * 1.1
-    assert ranked[0].score >= 0.8 or (ranked[0].memory.id == "memory2" and ranked[0].score >= boosted_score)
+    assert ranked[0].score >= 0.8 or (
+        ranked[0].memory.id == "memory2" and ranked[0].score >= boosted_score
+    )
 
 
 def test_health_check(retrieval_engine, mock_hippocampus, mock_cortex):
@@ -499,10 +473,7 @@ def test_health_check(retrieval_engine, mock_hippocampus, mock_cortex):
 
     health = retrieval_engine.health_check()
 
-    assert health == {
-        "hippocampus_healthy": {"status": "healthy"},
-        "cortex_healthy": True
-    }
+    assert health == {"hippocampus_healthy": {"status": "healthy"}, "cortex_healthy": True}
 
 
 @pytest.mark.asyncio
@@ -511,7 +482,7 @@ async def test_search_query_without_embedding(retrieval_engine, mock_cortex, sam
     query = SearchQuery(
         query="test query",
         top_k=5,
-        filters={"tags": ["test"]}
+        filters={"tags": ["test"]},
         # No embedding attribute
     )
 
@@ -524,11 +495,11 @@ async def test_search_query_without_embedding(retrieval_engine, mock_cortex, sam
 
 
 @pytest.mark.asyncio
-async def test_search_access_count_increment(retrieval_engine, mock_hippocampus, mock_cortex, sample_memory, sample_search_query):
+async def test_search_access_count_increment(
+    retrieval_engine, mock_hippocampus, mock_cortex, sample_memory, sample_search_query
+):
     """Test that access count is incremented for search results."""
-    mock_hippocampus.vector_search.return_value = [
-        {"memory": sample_memory, "score": 0.9}
-    ]
+    mock_hippocampus.vector_search.return_value = [{"memory": sample_memory, "score": 0.9}]
 
     results = await retrieval_engine.search(sample_search_query)
 
@@ -537,7 +508,9 @@ async def test_search_access_count_increment(retrieval_engine, mock_hippocampus,
 
 
 @pytest.mark.asyncio
-async def test_search_multiple_paths_integration(retrieval_engine, mock_hippocampus, mock_cortex, sample_memory):
+async def test_search_multiple_paths_integration(
+    retrieval_engine, mock_hippocampus, mock_cortex, sample_memory
+):
     """Test search using multiple retrieval paths."""
     # Create different memories for different paths
     vector_memory = Memory(
@@ -546,7 +519,7 @@ async def test_search_multiple_paths_integration(retrieval_engine, mock_hippocam
         text="Vector content",
         summary="Vector summary",
         source="test",
-        tags=["vector"]
+        tags=["vector"],
     )
 
     tag_memory = Memory(
@@ -555,13 +528,11 @@ async def test_search_multiple_paths_integration(retrieval_engine, mock_hippocam
         text="Tag content",
         summary="Tag summary",
         source="test",
-        tags=["test", "tag"]
+        tags=["test", "tag"],
     )
 
     # Setup mocks for all paths
-    mock_hippocampus.vector_search.return_value = [
-        {"memory": vector_memory, "score": 0.9}
-    ]
+    mock_hippocampus.vector_search.return_value = [{"memory": vector_memory, "score": 0.9}]
     mock_cortex.search_by_tags.return_value = [tag_memory]
     mock_cortex.get_memory_graph.return_value = {"nodes": []}
 
@@ -569,7 +540,7 @@ async def test_search_multiple_paths_integration(retrieval_engine, mock_hippocam
         query="test",
         top_k=10,
         filters={"tags": ["test"], "context_memory_id": "context-id"},
-        embedding=[0.1] * 768
+        embedding=[0.1] * 768,
     )
 
     results = await retrieval_engine.search(query)

--- a/tests/test_simple_api.py
+++ b/tests/test_simple_api.py
@@ -25,11 +25,7 @@ def test_episemic_initialization():
     assert episemic._started is False
 
     # Custom config
-    episemic = Episemic(
-        debug=True,
-        postgres_host="custom-host",
-        qdrant_port=9999
-    )
+    episemic = Episemic(debug=True, postgres_host="custom-host", qdrant_port=9999)
     assert episemic._config.debug is True
     assert episemic._config.postgresql.host == "custom-host"
     assert episemic._config.qdrant.port == 9999
@@ -87,7 +83,7 @@ def test_memory_wrapper():
         text="This is test content",
         summary="Test summary",
         source="test",
-        tags=["test", "memory"]
+        tags=["test", "memory"],
     )
 
     # Wrap it
@@ -115,13 +111,10 @@ def test_search_result_wrapper():
         text="Found content",
         summary="Found summary",
         source="test",
-        tags=["found"]
+        tags=["found"],
     )
 
-    internal_result = InternalSearchResult(
-        memory=internal_memory,
-        score=0.85
-    )
+    internal_result = InternalSearchResult(memory=internal_memory, score=0.85)
 
     # Wrap it
     result = SearchResult(internal_result)

--- a/tests/test_simple_api_comprehensive.py
+++ b/tests/test_simple_api_comprehensive.py
@@ -13,7 +13,7 @@ from episemic.simple import Episemic, EpistemicSync, Memory, SearchResult
 
 
 @pytest.mark.asyncio
-@patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer')
+@patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer")
 async def test_simple_api_comprehensive_workflow(mock_transformer):
     """Test comprehensive workflow with simple API."""
     # Mock the sentence transformer
@@ -33,7 +33,7 @@ async def test_simple_api_comprehensive_workflow(mock_transformer):
             "Python is a versatile programming language",
             title="Python Programming",
             tags=["python", "programming"],
-            metadata={"difficulty": "beginner"}
+            metadata={"difficulty": "beginner"},
         )
         assert memory1 is not None
         assert "Python" in memory1.text
@@ -43,7 +43,7 @@ async def test_simple_api_comprehensive_workflow(mock_transformer):
             "JavaScript is used for web development",
             title="JavaScript Basics",
             tags=["javascript", "web"],
-            metadata={"difficulty": "intermediate"}
+            metadata={"difficulty": "intermediate"},
         )
         assert memory2 is not None
 
@@ -70,7 +70,7 @@ async def test_simple_api_comprehensive_workflow(mock_transformer):
 
 
 @pytest.mark.asyncio
-@patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer')
+@patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer")
 async def test_simple_api_error_scenarios(mock_transformer):
     """Test simple API error handling scenarios."""
     # Mock the sentence transformer
@@ -100,7 +100,7 @@ async def test_simple_api_error_scenarios(mock_transformer):
     await episemic.start()
 
     # Test with API failures
-    with patch.object(episemic._api, 'store_memory', return_value=None):
+    with patch.object(episemic._api, "store_memory", return_value=None):
         memory = await episemic.remember("failed memory")
         assert memory is None
 
@@ -116,7 +116,7 @@ async def test_simple_api_error_scenarios(mock_transformer):
 
 def test_simple_api_sync_wrapper():
     """Test synchronous wrapper functionality."""
-    with patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer'):
+    with patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer"):
         mock_model = MagicMock()
         mock_model.encode.return_value.tolist.return_value = [0.3] * 384
 
@@ -134,9 +134,7 @@ def test_simple_api_sync_wrapper():
 
         # Test remember
         memory = sync_episemic.remember(
-            "Sync API test memory",
-            title="Sync Test",
-            tags=["sync", "test"]
+            "Sync API test memory", title="Sync Test", tags=["sync", "test"]
         )
         # May be None due to mocking
 
@@ -167,7 +165,7 @@ async def test_simple_api_configuration_variations():
         postgres_host="custom-host",
         postgres_db="custom-db",
         postgres_user="custom-user",
-        postgres_password="custom-pass"
+        postgres_password="custom-pass",
     )
     assert episemic_pg._config.postgresql.host == "custom-host"
     assert episemic_pg._config.postgresql.database == "custom-db"
@@ -175,18 +173,12 @@ async def test_simple_api_configuration_variations():
     assert episemic_pg._config.postgresql.password == "custom-pass"
 
     # Test with qdrant configuration via kwargs
-    episemic_qdrant = Episemic(
-        qdrant_host="qdrant-host",
-        qdrant_port=6334
-    )
+    episemic_qdrant = Episemic(qdrant_host="qdrant-host", qdrant_port=6334)
     assert episemic_qdrant._config.qdrant.host == "qdrant-host"
     assert episemic_qdrant._config.qdrant.port == 6334
 
     # Test with redis configuration via kwargs
-    episemic_redis = Episemic(
-        redis_host="redis-host",
-        redis_port=6380
-    )
+    episemic_redis = Episemic(redis_host="redis-host", redis_port=6380)
     assert episemic_redis._config.redis.host == "redis-host"
     assert episemic_redis._config.redis.port == 6380
 
@@ -202,7 +194,7 @@ def test_memory_wrapper_properties():
         summary="Test summary",
         source="test",
         tags=["test", "memory"],
-        metadata={"key": "value"}
+        metadata={"key": "value"},
     )
 
     wrapped_memory = Memory(internal_memory)
@@ -233,14 +225,11 @@ def test_search_result_wrapper():
         title="Result Memory",
         text="Result content",
         summary="Result summary",
-        source="test"
+        source="test",
     )
 
     internal_result = InternalSearchResult(
-        memory=internal_memory,
-        score=0.85,
-        context="search context",
-        metadata={"search": "data"}
+        memory=internal_memory, score=0.85, context="search context", metadata={"search": "data"}
     )
 
     wrapped_result = SearchResult(internal_result)
@@ -259,7 +248,7 @@ def test_search_result_wrapper():
 @pytest.mark.asyncio
 async def test_create_memory_system_function():
     """Test create_memory_system convenience function."""
-    with patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer'):
+    with patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer"):
         mock_model = MagicMock()
         mock_model.encode.return_value.tolist.return_value = [0.4] * 384
 
@@ -270,7 +259,7 @@ async def test_create_memory_system_function():
 
 
 @pytest.mark.asyncio
-@patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer')
+@patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer")
 async def test_simple_api_memory_retrieval_fallback(mock_transformer):
     """Test memory retrieval with fallback logic."""
     # Mock the sentence transformer
@@ -288,9 +277,7 @@ async def test_simple_api_memory_retrieval_fallback(mock_transformer):
     async with Episemic(config=config) as episemic:
         # This should use the fallback logic in remember()
         memory = await episemic.remember(
-            "Fallback test memory",
-            title="Fallback Test",
-            tags=["fallback"]
+            "Fallback test memory", title="Fallback Test", tags=["fallback"]
         )
         assert memory is not None
         assert memory.text == "Fallback test memory"
@@ -299,7 +286,7 @@ async def test_simple_api_memory_retrieval_fallback(mock_transformer):
 
 
 @pytest.mark.asyncio
-@patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer')
+@patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer")
 async def test_simple_api_consolidation_operations(mock_transformer):
     """Test consolidation operations through simple API."""
     # Mock the sentence transformer
@@ -340,13 +327,14 @@ def test_simple_api_event_loop_handling():
 
 
 @pytest.mark.asyncio
-@patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer')
+@patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer")
 async def test_simple_api_with_file_persistence(mock_transformer):
     """Test simple API with file-based persistence."""
     # Mock the sentence transformer
     mock_model = MagicMock()
     # Create a proper numpy-like array mock
     import numpy as np
+
     mock_array = np.array([0.7] * 384)
     mock_model.encode.return_value = mock_array
     mock_transformer.return_value = mock_model
@@ -365,10 +353,7 @@ async def test_simple_api_with_file_persistence(mock_transformer):
 
         # First session
         async with Episemic(config=config) as episemic1:
-            memory = await episemic1.remember(
-                "Persistent memory test",
-                title="Persistence Test"
-            )
+            memory = await episemic1.remember("Persistent memory test", title="Persistence Test")
             assert memory is not None
             memory_id = memory.id
 

--- a/tests/test_simple_api_error_coverage.py
+++ b/tests/test_simple_api_error_coverage.py
@@ -11,7 +11,7 @@ from episemic.simple import Episemic, EpistemicSync
 
 
 @pytest.mark.asyncio
-@patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer')
+@patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer")
 async def test_simple_api_start_failure_handling(mock_transformer):
     """Test simple API start failure handling."""
     # Mock the sentence transformer
@@ -29,7 +29,7 @@ async def test_simple_api_start_failure_handling(mock_transformer):
     episemic = Episemic(config=config)
 
     # Mock API initialization to fail
-    with patch.object(episemic._api, 'initialize', side_effect=Exception("Init failed")):
+    with patch.object(episemic._api, "initialize", side_effect=Exception("Init failed")):
         result = await episemic.start()
         assert result is False
         assert episemic._started is True  # Should still mark as started for basic functionality
@@ -55,7 +55,7 @@ def test_simple_api_sync_event_loop_edge_cases():
 
 
 @pytest.mark.asyncio
-@patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer')
+@patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer")
 async def test_simple_api_forget_functionality(mock_transformer):
     """Test forget functionality in simple API."""
     # Mock the sentence transformer
@@ -84,7 +84,7 @@ async def test_simple_api_forget_functionality(mock_transformer):
 
 
 @pytest.mark.asyncio
-@patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer')
+@patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer")
 async def test_simple_api_find_related_functionality(mock_transformer):
     """Test find_related functionality in simple API."""
     # Mock the sentence transformer
@@ -141,7 +141,7 @@ async def test_simple_api_not_started_edge_cases():
 
 
 @pytest.mark.asyncio
-@patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer')
+@patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer")
 async def test_simple_api_consolidation_edge_cases(mock_transformer):
     """Test consolidation edge cases in simple API."""
     # Mock the sentence transformer
@@ -164,7 +164,7 @@ async def test_simple_api_consolidation_edge_cases(mock_transformer):
 
 
 @pytest.mark.asyncio
-@patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer')
+@patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer")
 async def test_simple_api_health_check_variations(mock_transformer):
     """Test health check variations."""
     # Mock the sentence transformer
@@ -190,7 +190,7 @@ async def test_simple_api_health_check_variations(mock_transformer):
             "enable_cortex": False,
             "enable_consolidation": False,
             "enable_retrieval": False,
-        }
+        },
     ]
 
     for config_dict in configs:
@@ -201,7 +201,7 @@ async def test_simple_api_health_check_variations(mock_transformer):
 
 
 @pytest.mark.asyncio
-@patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer')
+@patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer")
 async def test_simple_api_memory_retrieval_error_handling(mock_transformer):
     """Test memory retrieval error handling."""
     # Mock the sentence transformer
@@ -218,19 +218,19 @@ async def test_simple_api_memory_retrieval_error_handling(mock_transformer):
 
     async with Episemic(config=config) as episemic:
         # Mock API get_memory to raise exception
-        with patch.object(episemic._api, 'get_memory', side_effect=Exception("Get memory failed")):
+        with patch.object(episemic._api, "get_memory", side_effect=Exception("Get memory failed")):
             # This should trigger the fallback logic in remember()
             memory = await episemic.remember("Test memory with error")
             assert memory is not None  # Should use fallback logic
 
         # Test get with API error - should raise exception (no error handling in get)
-        with patch.object(episemic._api, 'get_memory', side_effect=Exception("Get failed")):
+        with patch.object(episemic._api, "get_memory", side_effect=Exception("Get failed")):
             with pytest.raises(Exception, match="Get failed"):
                 await episemic.get("any-id")
 
 
 @pytest.mark.asyncio
-@patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer')
+@patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer")
 async def test_simple_api_config_kwargs_parsing(mock_transformer):
     """Test config kwargs parsing edge cases."""
     # Test with mixed kwargs
@@ -239,7 +239,7 @@ async def test_simple_api_config_kwargs_parsing(mock_transformer):
         postgres_db="custom-db",
         redis_port=6380,
         debug=True,
-        custom_field="custom_value"  # Should be added to config_dict
+        custom_field="custom_value",  # Should be added to config_dict
     )
 
     assert episemic._config.qdrant.host == "custom-qdrant"
@@ -250,7 +250,7 @@ async def test_simple_api_config_kwargs_parsing(mock_transformer):
 
 def test_simple_api_sync_wrapper_comprehensive():
     """Test comprehensive sync wrapper functionality."""
-    with patch('episemic.hippocampus.duckdb_hippocampus.SentenceTransformer'):
+    with patch("episemic.hippocampus.duckdb_hippocampus.SentenceTransformer"):
         config = EpistemicConfig()
         config.use_duckdb_fallback = True
         config.prefer_qdrant = False
@@ -261,9 +261,14 @@ def test_simple_api_sync_wrapper_comprehensive():
 
         # Test all sync methods exist and are callable
         methods_to_test = [
-            'start', 'remember', 'recall', 'get',
-            'find_related', 'forget', 'consolidate',
-            'health'
+            "start",
+            "remember",
+            "recall",
+            "get",
+            "find_related",
+            "forget",
+            "consolidate",
+            "health",
         ]
         # Note: 'auto_consolidate' and 'stop' methods don't exist in EpistemicSync
 


### PR DESCRIPTION
## Summary
- Implement `auto_consolidation_sweep()` method in ConsolidationEngine
- Add supporting methods to both hippocampus implementations
- Update tests to match new implementation

## Features Added
- **Auto Consolidation Sweep**: Automatically scans hippocampus for memories eligible for consolidation based on age and access count thresholds
- **Memory Scanning**: Added `get_all_memory_ids()` method to both DuckDB and Qdrant hippocampus implementations
- **Memory Cleanup**: Added `remove_memory()` method to remove successfully consolidated memories from hippocampus
- **Comprehensive Error Handling**: Graceful handling of missing methods and consolidation failures

## Implementation Details
- Uses existing `_should_consolidate()` logic for determining eligibility
- Consolidates memories from hippocampus (fast, episodic) to cortex (long-term, semantic)
- Removes memories from hippocampus after successful consolidation to prevent duplicates
- Returns count of successfully consolidated memories
- Maintains backward compatibility with existing consolidation functionality

## Test Results
- All consolidation tests passing (27/27)
- All hippocampus tests passing (37/37)
- Overall test suite: 289/290 tests passing (1 unrelated version test failure)
- Tests verified with both DuckDB and Qdrant storage backends

🤖 Generated with [Claude Code](https://claude.ai/code)